### PR TITLE
fix: gradlew 실행 권한 빌드 가능하도록 수정

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -30,7 +30,9 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Build with Gradle
-        run: ./gradlew clean build -x test
+        run: |
+          chmod +x gradlew
+          ./gradlew clean build -x test
 
       - name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
## 작업 내용

> gradlew 실행 권한을 빌드가 가능하도록 수정합니다.

## 참고 사항

> 

## 연관 이슈

> close #7


<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow reliability by ensuring proper permissions configuration during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->