### PR TITLE
feat: JWT 토큰 재발급 API 구현

### DIFF
--- a/src/main/java/com/example/gak/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/gak/domain/auth/controller/AuthController.java
@@ -1,0 +1,43 @@
+package com.example.gak.domain.auth.controller;
+
+import java.time.Instant;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.gak.domain.auth.dto.TokenPair;
+import com.example.gak.domain.auth.service.AuthService;
+import com.example.gak.global.apiPayload.ApiResponse;
+import com.example.gak.global.security.AuthCookieProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final AuthService authService;
+
+	@GetMapping("/refresh")
+	public ResponseEntity<ApiResponse<Void>> refreshToken(
+		@CookieValue(value = "refreshToken", required = false) String refreshToken
+	) {
+		TokenPair tokenPair = authService.refreshToken(refreshToken, Instant.now());
+
+		return ResponseEntity.ok()
+			.header(
+				HttpHeaders.SET_COOKIE,
+				AuthCookieProvider.createAccessTokenCookie(tokenPair.getAccessToken()).toString()
+			)
+			.header(
+				HttpHeaders.SET_COOKIE,
+				AuthCookieProvider.createRefreshTokenCookie(tokenPair.getRefreshToken()).toString()
+			)
+			.body(ApiResponse.onSuccess(null));
+	}
+}

--- a/src/main/java/com/example/gak/domain/auth/dto/TokenPair.java
+++ b/src/main/java/com/example/gak/domain/auth/dto/TokenPair.java
@@ -1,0 +1,12 @@
+package com.example.gak.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class TokenPair {
+
+	private final String accessToken;
+	private final String refreshToken;
+}

--- a/src/main/java/com/example/gak/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/gak/domain/auth/service/AuthService.java
@@ -22,6 +22,10 @@ public class AuthService {
 	private final JwtService jwtService;
 
 	public TokenPair refreshToken(String refreshToken, Instant now) {
+		if (refreshToken == null) {
+			throw new GeneralException(GeneralErrorCode.REFRESH_TOKEN_REQUIRED);
+		}
+
 		Long memberId;
 		try {
 			memberId = jwtProvider.extractMemberId(refreshToken);
@@ -31,15 +35,20 @@ public class AuthService {
 			throw new GeneralException(GeneralErrorCode.INVALID_TOKEN_FORMAT);
 		}
 
-		if (jwtService.getRefreshToken(memberId) == null) {
+		String storedRefreshToken = jwtService.getRefreshToken(memberId);
+		if (storedRefreshToken == null) {
 			throw new GeneralException(GeneralErrorCode.NOT_FOUND_REFRESH_TOKEN);
 		}
+		if (!storedRefreshToken.equals(refreshToken)) {
+			throw new GeneralException(GeneralErrorCode.REFRESH_TOKEN_MISMATCH);
+		}
+
 		jwtService.deleteRefreshToken(memberId);
 
 		String accessToken = jwtProvider.createAccessToken(memberId, now);
-		refreshToken = jwtProvider.createRefreshToken(memberId, now);
-		jwtService.saveRefreshToken(memberId, refreshToken, now);
+		String newRefreshToken = jwtProvider.createRefreshToken(memberId, now);
+		jwtService.saveRefreshToken(memberId, newRefreshToken, now);
 
-		return new TokenPair(accessToken, refreshToken);
+		return new TokenPair(accessToken, newRefreshToken);
 	}
 }

--- a/src/main/java/com/example/gak/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/gak/domain/auth/service/AuthService.java
@@ -1,0 +1,45 @@
+package com.example.gak.domain.auth.service;
+
+import java.time.Instant;
+
+import org.springframework.stereotype.Service;
+
+import com.example.gak.domain.auth.dto.TokenPair;
+import com.example.gak.global.apiPayload.code.GeneralErrorCode;
+import com.example.gak.global.apiPayload.exception.GeneralException;
+import com.example.gak.global.security.jwt.JwtProvider;
+import com.example.gak.global.security.jwt.JwtService;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final JwtProvider jwtProvider;
+	private final JwtService jwtService;
+
+	public TokenPair refreshToken(String refreshToken, Instant now) {
+		Long memberId;
+		try {
+			memberId = jwtProvider.extractMemberId(refreshToken);
+		} catch (ExpiredJwtException e) {
+			throw new GeneralException(GeneralErrorCode.REFRESH_TOKEN_EXPIRED);
+		} catch (JwtException e) {
+			throw new GeneralException(GeneralErrorCode.INVALID_TOKEN_FORMAT);
+		}
+
+		if (jwtService.getRefreshToken(memberId) == null) {
+			throw new GeneralException(GeneralErrorCode.NOT_FOUND_REFRESH_TOKEN);
+		}
+		jwtService.deleteRefreshToken(memberId);
+
+		String accessToken = jwtProvider.createAccessToken(memberId, now);
+		refreshToken = jwtProvider.createRefreshToken(memberId, now);
+		jwtService.saveRefreshToken(memberId, refreshToken, now);
+
+		return new TokenPair(accessToken, refreshToken);
+	}
+}

--- a/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
@@ -19,13 +19,13 @@ public enum GeneralErrorCode implements BaseErrorCode {
 	INVALID_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "AUTH401_2", "토큰 형식이 올바르지 않습니다."),
 	ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_3", "기한이 만료된 Access 토큰입니다."),
 	UNSUPPORTED_PROVIDER(HttpStatus.UNAUTHORIZED, "AUTH401_4", "지원하지 않는 소셜 로그인 제공자입니다."),
+	REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_5", "기한이 만료된 Refresh 토큰입니다."),
+	NOT_FOUND_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_6", "존재하지 않는 Refresh 토큰입니다."),
 
 	// AWS S3 관련
 	S3_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500_1", "S3 업로드에 실패했습니다."),
 	S3_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500_2", "S3 파일 삭제에 실패했습니다."),
-	S3_DOWNLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500_3", "S3 파일 조회에 실패했습니다.")
-	;
-
+	S3_DOWNLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500_3", "S3 파일 조회에 실패했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
@@ -21,6 +21,8 @@ public enum GeneralErrorCode implements BaseErrorCode {
 	UNSUPPORTED_PROVIDER(HttpStatus.UNAUTHORIZED, "AUTH401_4", "지원하지 않는 소셜 로그인 제공자입니다."),
 	REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_5", "기한이 만료된 Refresh 토큰입니다."),
 	NOT_FOUND_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_6", "존재하지 않는 Refresh 토큰입니다."),
+	REFRESH_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH401_7", "Refresh 토큰이 전달되지 않았습니다."),
+	REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH401_8", "Refresh 토큰 정보가 일치하지 않습니다."),
 
 	// AWS S3 관련
 	S3_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500_1", "S3 업로드에 실패했습니다."),

--- a/src/main/java/com/example/gak/global/security/jwt/JwtService.java
+++ b/src/main/java/com/example/gak/global/security/jwt/JwtService.java
@@ -28,12 +28,12 @@ public class JwtService {
 		stringRedisTemplate.opsForValue().set(key, refreshToken, ttl);
 	}
 
-	public String getRefreshToken(String memberId) {
+	public String getRefreshToken(Long memberId) {
 		String key = REFRESH_TOKEN_PREFIX + memberId;
 		return stringRedisTemplate.opsForValue().get(key);
 	}
 
-	public void deleteRefreshToken(String memberId) {
+	public void deleteRefreshToken(Long memberId) {
 		String key = REFRESH_TOKEN_PREFIX + memberId;
 		stringRedisTemplate.delete(key);
 	}


### PR DESCRIPTION
## 작업 내용

- Refresh 토큰 유효성 검증
  - 요청 토큰 null 여부
  - 토큰 형태
  - 토큰 만료 여부
  - Redis 존재 여부
  - 요청 토큰과 저장된 토큰의 일치 여부
- 검증 완료 후 Redis에서 기존 Refresh 토큰 삭제 및 새로운 Refresh 토큰 저장
- 재발급 토큰들은 쿠키로 응답

## 참고 사항

> NONE

## 연관 이슈

> close #26 


<br>