### PR TITLE
refactor: 소셜 로그인 완료 후의 토큰 전달 방식 수정

### DIFF
--- a/src/main/java/com/example/gak/global/security/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/example/gak/global/security/oauth2/CustomSuccessHandler.java
@@ -1,16 +1,16 @@
 package com.example.gak.global.security.oauth2;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
-import com.example.gak.global.security.AuthCookieProvider;
 import com.example.gak.global.security.jwt.JwtProvider;
 import com.example.gak.global.security.jwt.JwtService;
 
@@ -42,20 +42,22 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		String refreshToken = jwtProvider.createRefreshToken(memberId, now);
 
 		String redirectUrl = String.format(
-			"http://localhost:3000/auth/callback/%s",
-			registrationId
+			"http://localhost:3000/auth/callback/%s?accessToken=%s&refreshToken=%s",
+			registrationId,
+			URLEncoder.encode(accessToken, StandardCharsets.UTF_8),
+			URLEncoder.encode(refreshToken, StandardCharsets.UTF_8)
 		);
 
 		jwtService.saveRefreshToken(memberId, refreshToken, now);
 
-		response.addHeader(
+		/*response.addHeader(
 			HttpHeaders.SET_COOKIE,
 			AuthCookieProvider.createAccessTokenCookie(accessToken).toString()
 		);
 		response.addHeader(
 			HttpHeaders.SET_COOKIE,
 			AuthCookieProvider.createRefreshTokenCookie(refreshToken).toString()
-		);
+		);*/
 		response.sendRedirect(redirectUrl);
 	}
 }


### PR DESCRIPTION
## 작업 내용

- 소셜 로그인 완료 후 토큰 전달 방식을 쿠키에서 쿼리 파라미터로 수정

## 참고 사항

> 프론트 로컬 테스트 시 쿠키가 받아지지 않는 이슈가 있어 수정합니다.

## 연관 이슈

> close #29 


<br>