### PR TITLE
refactor: 토큰 재발급 후 쿠키가 아닌 바디로 전달하도록 수정

### DIFF
--- a/src/main/java/com/example/gak/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/gak/domain/auth/controller/AuthController.java
@@ -24,21 +24,12 @@ public class AuthController {
 	private final AuthService authService;
 
 	@PostMapping("/refresh")
-	public ResponseEntity<ApiResponse<Void>> refreshToken(
+	public ResponseEntity<ApiResponse<TokenPair>> refreshToken(
 		@CookieValue(value = "refreshToken", required = false) String refreshToken
 	) {
 		TokenPair tokenPair = authService.refreshToken(refreshToken, Instant.now());
 
-		return ResponseEntity.ok()
-			.header(
-				HttpHeaders.SET_COOKIE,
-				AuthCookieProvider.createAccessTokenCookie(tokenPair.getAccessToken()).toString()
-			)
-			.header(
-				HttpHeaders.SET_COOKIE,
-				AuthCookieProvider.createRefreshTokenCookie(tokenPair.getRefreshToken()).toString()
-			)
-			.body(ApiResponse.onSuccess(null));
+		return ResponseEntity.ok(ApiResponse.onSuccess(tokenPair));
 	}
 
 	@PostMapping("/logout")


### PR DESCRIPTION
## 작업 내용

- 토큰 재발급 후 쿠키가 아닌 바디로 전달하도록 수정

## 참고 사항

> NONE

## 연관 이슈

> close #32 


<br>