### PR TITLE
feat: 회원 프로필 조회 API 구현

### DIFF
--- a/src/main/java/com/example/gak/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/gak/domain/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.gak.domain.member.dto.MemberResponseDTO;
+import com.example.gak.domain.member.service.MemberCommandService;
 import com.example.gak.domain.member.service.MemberQueryService;
 import com.example.gak.global.apiPayload.ApiResponse;
 import com.example.gak.global.security.oauth2.CustomOAuth2User;
@@ -16,13 +17,16 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/members")
 @RequiredArgsConstructor
 public class MemberController {
-	
+
 	private final MemberQueryService memberQueryService;
+	private final MemberCommandService memberCommandService;
 
 	@GetMapping("/me")
 	public ApiResponse<MemberResponseDTO> getMember(@AuthenticationPrincipal CustomOAuth2User oAuth2User) {
-		return ApiResponse.onSuccess(
-			memberQueryService.getMember(oAuth2User.getMemberId())
-		);
+		Long memberId = oAuth2User.getMemberId();
+		MemberResponseDTO response = memberQueryService.getMember(memberId);
+		memberCommandService.markFirstLoginComplete(memberId);
+
+		return ApiResponse.onSuccess(response);
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/gak/domain/member/controller/MemberController.java
@@ -1,0 +1,28 @@
+package com.example.gak.domain.member.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.gak.domain.member.dto.MemberResponseDTO;
+import com.example.gak.domain.member.service.MemberQueryService;
+import com.example.gak.global.apiPayload.ApiResponse;
+import com.example.gak.global.security.oauth2.CustomOAuth2User;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+	
+	private final MemberQueryService memberQueryService;
+
+	@GetMapping("/me")
+	public ApiResponse<MemberResponseDTO> getMember(@AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+		return ApiResponse.onSuccess(
+			memberQueryService.getMember(oAuth2User.getMemberId())
+		);
+	}
+}

--- a/src/main/java/com/example/gak/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/gak/domain/member/dto/MemberResponseDTO.java
@@ -1,0 +1,20 @@
+package com.example.gak.domain.member.dto;
+
+import com.example.gak.domain.common.entity.enums.SessionCategory;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MemberResponseDTO {
+
+	private Long id;
+	private String nickname;
+	private String profileImageUrl;
+	private String bio;
+	private SessionCategory firstInterestCategory;
+	private SessionCategory secondInterestCategory;
+	private SessionCategory thirdInterestCategory;
+	private boolean firstLogin;
+}

--- a/src/main/java/com/example/gak/domain/member/entity/Member.java
+++ b/src/main/java/com/example/gak/domain/member/entity/Member.java
@@ -67,4 +67,8 @@ public class Member extends BaseEntity {
 		this.providerId = providerId;
 		this.firstLogin = true;
 	}
+
+	public void markLoginDone() {
+		firstLogin = false;
+	}
 }

--- a/src/main/java/com/example/gak/domain/member/entity/Member.java
+++ b/src/main/java/com/example/gak/domain/member/entity/Member.java
@@ -32,26 +32,39 @@ public class Member extends BaseEntity {
 	private String bio;
 
 	@Enumerated(EnumType.STRING)
-	private SessionCategory interestCategory;
+	private SessionCategory firstInterestCategory;
+
+	@Enumerated(EnumType.STRING)
+	private SessionCategory secondInterestCategory;
+
+	@Enumerated(EnumType.STRING)
+	private SessionCategory thirdInterestCategory;
 
 	@Column(nullable = false)
 	private String socialProvider;
 
 	private String providerId;
 
+	private boolean firstLogin;
+
 	public Member(
 		String nickname,
 		String profileImageUrl,
 		String bio,
-		SessionCategory interestCategory,
+		SessionCategory firstInterestCategory,
+		SessionCategory secondInterestCategory,
+		SessionCategory thirdInterestCategory,
 		String socialProvider,
 		String providerId
 	) {
 		this.nickname = nickname;
 		this.profileImageUrl = profileImageUrl;
 		this.bio = bio;
-		this.interestCategory = interestCategory;
+		this.firstInterestCategory = firstInterestCategory;
+		this.secondInterestCategory = secondInterestCategory;
+		this.thirdInterestCategory = thirdInterestCategory;
 		this.socialProvider = socialProvider;
 		this.providerId = providerId;
+		this.firstLogin = true;
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class MemberService {
+public class MemberCommandService {
 
 	private final MemberRepository memberRepository;
 

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -28,6 +28,8 @@ public class MemberCommandService {
 						oAuth2MemberDto.getProfileImage().orElse(""), // 기본 이미지 디자인 완성 시 URL 추가
 						null,
 						null,
+						null,
+						null,
 						oAuth2MemberDto.getProvider(),
 						oAuth2MemberDto.getProviderId()
 					);

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -5,6 +5,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.gak.domain.member.entity.Member;
 import com.example.gak.domain.member.repository.MemberRepository;
+import com.example.gak.global.apiPayload.code.GeneralErrorCode;
+import com.example.gak.global.apiPayload.exception.GeneralException;
 import com.example.gak.global.security.oauth2.dto.OAuth2MemberDto;
 
 import lombok.RequiredArgsConstructor;
@@ -36,5 +38,14 @@ public class MemberCommandService {
 					return memberRepository.save(member).getId();
 				}
 			);
+	}
+
+	public void markFirstLoginComplete(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
+
+		if (member.isFirstLogin()) {
+			member.markLoginDone();
+		}
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberQueryService.java
@@ -1,0 +1,42 @@
+package com.example.gak.domain.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.gak.domain.member.dto.MemberResponseDTO;
+import com.example.gak.domain.member.entity.Member;
+import com.example.gak.domain.member.repository.MemberRepository;
+import com.example.gak.global.apiPayload.code.GeneralErrorCode;
+import com.example.gak.global.apiPayload.exception.GeneralException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberQueryService {
+
+	private final MemberRepository memberRepository;
+
+	public MemberResponseDTO getMember(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
+
+		MemberResponseDTO response = MemberResponseDTO.builder()
+			.id(member.getId())
+			.nickname(member.getNickname())
+			.profileImageUrl(member.getProfileImageUrl())
+			.bio(member.getBio())
+			.firstInterestCategory(member.getFirstInterestCategory())
+			.secondInterestCategory(member.getSecondInterestCategory())
+			.thirdInterestCategory(member.getThirdInterestCategory())
+			.firstLogin(member.isFirstLogin())
+			.build();
+
+		if (member.isFirstLogin()) {
+			member.markLoginDone();
+		}
+
+		return response;
+	}
+}

--- a/src/main/java/com/example/gak/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberQueryService.java
@@ -22,7 +22,7 @@ public class MemberQueryService {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
 
-		MemberResponseDTO response = MemberResponseDTO.builder()
+		return MemberResponseDTO.builder()
 			.id(member.getId())
 			.nickname(member.getNickname())
 			.profileImageUrl(member.getProfileImageUrl())
@@ -32,11 +32,5 @@ public class MemberQueryService {
 			.thirdInterestCategory(member.getThirdInterestCategory())
 			.firstLogin(member.isFirstLogin())
 			.build();
-
-		if (member.isFirstLogin()) {
-			member.markLoginDone();
-		}
-
-		return response;
 	}
 }

--- a/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
@@ -24,6 +24,9 @@ public enum GeneralErrorCode implements BaseErrorCode {
 	REFRESH_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH401_7", "Refresh 토큰이 전달되지 않았습니다."),
 	REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH401_8", "Refresh 토큰 정보가 일치하지 않습니다."),
 
+	// 회원 관련
+	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "MEMBER404_1", "존재하지 않는 회원입니다."),
+
 	// AWS S3 관련
 	S3_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500_1", "S3 업로드에 실패했습니다."),
 	S3_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500_2", "S3 파일 삭제에 실패했습니다."),

--- a/src/main/java/com/example/gak/global/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/gak/global/security/oauth2/CustomOAuth2UserService.java
@@ -8,7 +8,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 
-import com.example.gak.domain.member.service.MemberService;
+import com.example.gak.domain.member.service.MemberCommandService;
 import com.example.gak.global.apiPayload.code.GeneralErrorCode;
 import com.example.gak.global.apiPayload.exception.GeneralException;
 import com.example.gak.global.security.oauth2.dto.KakaoMemberDto;
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
-	private final MemberService memberService;
+	private final MemberCommandService memberCommandService;
 
 	@Override
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -30,7 +30,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 		if (registrationId.equals("kakao")) {
 			KakaoMemberDto kakaoMemberResponse = new KakaoMemberDto(registrationId, attributes);
-			Long memberId = memberService.synchronize(kakaoMemberResponse);
+			Long memberId = memberCommandService.synchronize(kakaoMemberResponse);
 			return new CustomOAuth2User(registrationId, memberId);
 		}
 

--- a/src/main/java/com/example/gak/global/security/oauth2/CustomOidcUserService.java
+++ b/src/main/java/com/example/gak/global/security/oauth2/CustomOidcUserService.java
@@ -9,7 +9,7 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 
-import com.example.gak.domain.member.service.MemberService;
+import com.example.gak.domain.member.service.MemberCommandService;
 import com.example.gak.global.apiPayload.code.GeneralErrorCode;
 import com.example.gak.global.apiPayload.exception.GeneralException;
 import com.example.gak.global.security.oauth2.dto.GoogleMemberDto;
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CustomOidcUserService extends OidcUserService {
 
-	private final MemberService memberService;
+	private final MemberCommandService memberCommandService;
 
 	@Override
 	public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
@@ -31,7 +31,7 @@ public class CustomOidcUserService extends OidcUserService {
 
 		if (registrationId.equals("google")) {
 			GoogleMemberDto googleMemberResponse = new GoogleMemberDto(registrationId, attributes);
-			Long memberId = memberService.synchronize(googleMemberResponse);
+			Long memberId = memberCommandService.synchronize(googleMemberResponse);
 			return new CustomOidcUser(registrationId, memberId);
 		}
 


### PR DESCRIPTION
## 작업 내용

- 회원 엔티티 정보에 첫 로그인 여부, 2~3번째 선호 카테고리 추가
- 회원 프로필 조회 시 응답 생성 후, 첫 로그인 여부 확인
  - 첫 로그인 상태라면 응답 생성 후, 로그인 완료 체크

## 참고 사항

- 쿼리와 커맨드를 분리하기 위해 프로필 조회 후 로그인 완료 마킹 작업은 별도의 메서드로 분리했습니다. (컨트롤러에서 두 메서드를 순서대로 호출합니다)

## 연관 이슈

> close #38 


<br>