### PR TITLE
feat: 회원 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/example/gak/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/gak/domain/member/controller/MemberController.java
@@ -3,11 +3,13 @@ package com.example.gak.domain.member.controller;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.example.gak.domain.member.dto.MemberRequestDTO;
 import com.example.gak.domain.member.dto.MemberResponseDTO;
 import com.example.gak.domain.member.service.MemberCommandService;
 import com.example.gak.domain.member.service.MemberQueryService;
@@ -42,6 +44,16 @@ public class MemberController {
 	) {
 		return ApiResponse.onSuccess(
 			memberCommandService.updateProfileImage(oAuth2User.getMemberId(), profileImage)
+		);
+	}
+
+	@PatchMapping("/me/nickname")
+	public ApiResponse<MemberResponseDTO.UpdateMemberResponseDTO> updateNickname(
+		@AuthenticationPrincipal CustomOAuth2User oAuth2User,
+		@RequestBody MemberRequestDTO.UpdateMemberNicknameRequestDTO request
+	) {
+		return ApiResponse.onSuccess(
+			memberCommandService.updateNickname(oAuth2User.getMemberId(), request)
 		);
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/gak/domain/member/controller/MemberController.java
@@ -57,4 +57,14 @@ public class MemberController {
 			memberCommandService.updateNickname(oAuth2User.getMemberId(), request)
 		);
 	}
+
+	@PatchMapping("/me/interest-categories")
+	public ApiResponse<MemberResponseDTO.UpdateMemberResponseDTO> updateInterestCategories(
+		@AuthenticationPrincipal CustomOAuth2User oAuth2User,
+		@RequestBody MemberRequestDTO.UpdateMemberInterestCategoriesRequestDTO request
+	) {
+		return ApiResponse.onSuccess(
+			memberCommandService.updateInterestCategories(oAuth2User.getMemberId(), request)
+		);
+	}
 }

--- a/src/main/java/com/example/gak/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/gak/domain/member/controller/MemberController.java
@@ -16,6 +16,7 @@ import com.example.gak.domain.member.service.MemberQueryService;
 import com.example.gak.global.apiPayload.ApiResponse;
 import com.example.gak.global.security.oauth2.CustomOAuth2User;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -50,7 +51,7 @@ public class MemberController {
 	@PatchMapping("/me/nickname")
 	public ApiResponse<MemberResponseDTO.UpdateMemberResponseDTO> updateNickname(
 		@AuthenticationPrincipal CustomOAuth2User oAuth2User,
-		@RequestBody MemberRequestDTO.UpdateMemberNicknameRequestDTO request
+		@Valid @RequestBody MemberRequestDTO.UpdateMemberNicknameRequestDTO request
 	) {
 		return ApiResponse.onSuccess(
 			memberCommandService.updateNickname(oAuth2User.getMemberId(), request)

--- a/src/main/java/com/example/gak/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/gak/domain/member/controller/MemberController.java
@@ -22,9 +22,11 @@ public class MemberController {
 	private final MemberCommandService memberCommandService;
 
 	@GetMapping("/me")
-	public ApiResponse<MemberResponseDTO> getMember(@AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+	public ApiResponse<MemberResponseDTO.GetMemberResponseDTO> getMember(
+		@AuthenticationPrincipal CustomOAuth2User oAuth2User
+	) {
 		Long memberId = oAuth2User.getMemberId();
-		MemberResponseDTO response = memberQueryService.getMember(memberId);
+		MemberResponseDTO.GetMemberResponseDTO response = memberQueryService.getMember(memberId);
 		memberCommandService.markFirstLoginComplete(memberId);
 
 		return ApiResponse.onSuccess(response);

--- a/src/main/java/com/example/gak/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/gak/domain/member/controller/MemberController.java
@@ -2,8 +2,11 @@ package com.example.gak.domain.member.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.example.gak.domain.member.dto.MemberResponseDTO;
 import com.example.gak.domain.member.service.MemberCommandService;
@@ -30,5 +33,15 @@ public class MemberController {
 		memberCommandService.markFirstLoginComplete(memberId);
 
 		return ApiResponse.onSuccess(response);
+	}
+
+	@PatchMapping("/me/profile-image")
+	public ApiResponse<MemberResponseDTO.UpdateMemberResponseDTO> updateProfileImage(
+		@AuthenticationPrincipal CustomOAuth2User oAuth2User,
+		@RequestPart(value = "profileImage", required = false) MultipartFile profileImage
+	) {
+		return ApiResponse.onSuccess(
+			memberCommandService.updateProfileImage(oAuth2User.getMemberId(), profileImage)
+		);
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/example/gak/domain/member/converter/MemberConverter.java
@@ -1,0 +1,20 @@
+package com.example.gak.domain.member.converter;
+
+import com.example.gak.domain.member.dto.MemberResponseDTO;
+import com.example.gak.domain.member.entity.Member;
+
+public class MemberConverter {
+
+	public static MemberResponseDTO.GetMemberResponseDTO toGetMemberResponseDTO(Member member) {
+		return MemberResponseDTO.GetMemberResponseDTO.builder()
+			.id(member.getId())
+			.nickname(member.getNickname())
+			.profileImageUrl(member.getProfileImageUrl())
+			.bio(member.getBio())
+			.firstInterestCategory(member.getFirstInterestCategory())
+			.secondInterestCategory(member.getSecondInterestCategory())
+			.thirdInterestCategory(member.getThirdInterestCategory())
+			.firstLogin(member.isFirstLogin())
+			.build();
+	}
+}

--- a/src/main/java/com/example/gak/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/example/gak/domain/member/converter/MemberConverter.java
@@ -17,4 +17,16 @@ public class MemberConverter {
 			.firstLogin(member.isFirstLogin())
 			.build();
 	}
+
+	public static MemberResponseDTO.UpdateMemberResponseDTO toUpdateMemberResponseDTO(Member member) {
+		return MemberResponseDTO.UpdateMemberResponseDTO.builder()
+			.id(member.getId())
+			.nickname(member.getNickname())
+			.profileImageUrl(member.getProfileImageUrl())
+			.bio(member.getBio())
+			.firstInterestCategory(member.getFirstInterestCategory())
+			.secondInterestCategory(member.getSecondInterestCategory())
+			.thirdInterestCategory(member.getThirdInterestCategory())
+			.build();
+	}
 }

--- a/src/main/java/com/example/gak/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/example/gak/domain/member/dto/MemberRequestDTO.java
@@ -3,6 +3,7 @@ package com.example.gak.domain.member.dto;
 import com.example.gak.domain.common.entity.enums.SessionCategory;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,8 +18,12 @@ public class MemberRequestDTO {
 	@Getter
 	public static class UpdateMemberNicknameRequestDTO {
 
+		@Pattern(
+			regexp = "^[a-zA-Z0-9가-힣]+$",
+			message = "닉네임은 한글, 영어, 숫자만 가능합니다."
+		)
 		@NotBlank
-		@Size(min = 2, max = 12)
+		@Size(min = 2, max = 10)
 		private String nickname;
 	}
 

--- a/src/main/java/com/example/gak/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/example/gak/domain/member/dto/MemberRequestDTO.java
@@ -1,0 +1,18 @@
+package com.example.gak.domain.member.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Builder;
+import lombok.Getter;
+
+public class MemberRequestDTO {
+
+	@Builder
+	@Getter
+	public static class UpdateMemberNicknameRequestDTO {
+
+		@Min(2)
+		@Max(12)
+		private String nickname;
+	}
+}

--- a/src/main/java/com/example/gak/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/example/gak/domain/member/dto/MemberRequestDTO.java
@@ -1,5 +1,7 @@
 package com.example.gak.domain.member.dto;
 
+import com.example.gak.domain.common.entity.enums.SessionCategory;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -18,5 +20,15 @@ public class MemberRequestDTO {
 		@NotBlank
 		@Size(min = 2, max = 12)
 		private String nickname;
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class UpdateMemberInterestCategoriesRequestDTO {
+		private SessionCategory firstInterestCategory;
+		private SessionCategory secondInterestCategory;
+		private SessionCategory thirdInterestCategory;
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/example/gak/domain/member/dto/MemberRequestDTO.java
@@ -2,11 +2,15 @@ package com.example.gak.domain.member.dto;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class MemberRequestDTO {
 
+	@AllArgsConstructor
+	@NoArgsConstructor
 	@Builder
 	@Getter
 	public static class UpdateMemberNicknameRequestDTO {

--- a/src/main/java/com/example/gak/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/example/gak/domain/member/dto/MemberRequestDTO.java
@@ -1,7 +1,7 @@
 package com.example.gak.domain.member.dto;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,8 +15,8 @@ public class MemberRequestDTO {
 	@Getter
 	public static class UpdateMemberNicknameRequestDTO {
 
-		@Min(2)
-		@Max(12)
+		@NotBlank
+		@Size(min = 2, max = 12)
 		private String nickname;
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/gak/domain/member/dto/MemberResponseDTO.java
@@ -5,16 +5,18 @@ import com.example.gak.domain.common.entity.enums.SessionCategory;
 import lombok.Builder;
 import lombok.Getter;
 
-@Builder
-@Getter
 public class MemberResponseDTO {
 
-	private Long id;
-	private String nickname;
-	private String profileImageUrl;
-	private String bio;
-	private SessionCategory firstInterestCategory;
-	private SessionCategory secondInterestCategory;
-	private SessionCategory thirdInterestCategory;
-	private boolean firstLogin;
+	@Builder
+	@Getter
+	public static class GetMemberResponseDTO {
+		private Long id;
+		private String nickname;
+		private String profileImageUrl;
+		private String bio;
+		private SessionCategory firstInterestCategory;
+		private SessionCategory secondInterestCategory;
+		private SessionCategory thirdInterestCategory;
+		private boolean firstLogin;
+	}
 }

--- a/src/main/java/com/example/gak/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/gak/domain/member/dto/MemberResponseDTO.java
@@ -19,4 +19,16 @@ public class MemberResponseDTO {
 		private SessionCategory thirdInterestCategory;
 		private boolean firstLogin;
 	}
+
+	@Builder
+	@Getter
+	public static class UpdateMemberResponseDTO {
+		private Long id;
+		private String nickname;
+		private String profileImageUrl;
+		private String bio;
+		private SessionCategory firstInterestCategory;
+		private SessionCategory secondInterestCategory;
+		private SessionCategory thirdInterestCategory;
+	}
 }

--- a/src/main/java/com/example/gak/domain/member/entity/Member.java
+++ b/src/main/java/com/example/gak/domain/member/entity/Member.java
@@ -67,6 +67,10 @@ public class Member extends BaseEntity {
 		this.providerId = providerId;
 		this.firstLogin = true;
 	}
+	
+	public String getDisplayNickname() {
+		return nickname + " #" + id;
+	}
 
 	public void markLoginDone() {
 		firstLogin = false;

--- a/src/main/java/com/example/gak/domain/member/entity/Member.java
+++ b/src/main/java/com/example/gak/domain/member/entity/Member.java
@@ -71,4 +71,8 @@ public class Member extends BaseEntity {
 	public void markLoginDone() {
 		firstLogin = false;
 	}
+
+	public void updateProfileImageUrl(String profileImageUrl) {
+		this.profileImageUrl = profileImageUrl;
+	}
 }

--- a/src/main/java/com/example/gak/domain/member/entity/Member.java
+++ b/src/main/java/com/example/gak/domain/member/entity/Member.java
@@ -75,4 +75,8 @@ public class Member extends BaseEntity {
 	public void updateProfileImageUrl(String profileImageUrl) {
 		this.profileImageUrl = profileImageUrl;
 	}
+
+	public void updateNickname(String nickname) {
+		this.nickname = nickname;
+	}
 }

--- a/src/main/java/com/example/gak/domain/member/entity/Member.java
+++ b/src/main/java/com/example/gak/domain/member/entity/Member.java
@@ -67,7 +67,7 @@ public class Member extends BaseEntity {
 		this.providerId = providerId;
 		this.firstLogin = true;
 	}
-	
+
 	public String getDisplayNickname() {
 		return nickname + " #" + id;
 	}
@@ -82,5 +82,15 @@ public class Member extends BaseEntity {
 
 	public void updateNickname(String nickname) {
 		this.nickname = nickname;
+	}
+
+	public void updateInterestCategories(
+		SessionCategory firstInterestCategory,
+		SessionCategory secondInterestCategory,
+		SessionCategory thirdInterestCategory
+	) {
+		this.firstInterestCategory = firstInterestCategory;
+		this.secondInterestCategory = secondInterestCategory;
+		this.thirdInterestCategory = thirdInterestCategory;
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -82,6 +82,20 @@ public class MemberCommandService {
 		return MemberConverter.toUpdateMemberResponseDTO(member);
 	}
 
+	public MemberResponseDTO.UpdateMemberResponseDTO updateInterestCategories(
+		Long memberId,
+		MemberRequestDTO.UpdateMemberInterestCategoriesRequestDTO request
+	) {
+		Member member = getMember(memberId);
+		member.updateInterestCategories(
+			request.getFirstInterestCategory(),
+			request.getSecondInterestCategory(),
+			request.getThirdInterestCategory()
+		);
+
+		return MemberConverter.toUpdateMemberResponseDTO(member);
+	}
+
 	private Member getMember(Long memberId) {
 		return memberRepository.findById(memberId)
 			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -54,20 +54,23 @@ public class MemberCommandService {
 		}
 	}
 
-	public MemberResponseDTO.UpdateMemberResponseDTO updateProfileImage(Long memberId, MultipartFile profileImage) {
+	public MemberResponseDTO.UpdateMemberResponseDTO updateProfileImage(Long memberId, MultipartFile newProfileImage) {
 		Member member = getMember(memberId);
 
-		if (profileImage == null) {
+		if (newProfileImage == null) {
 			return MemberConverter.toUpdateMemberResponseDTO(member);
 		}
 
-		String profileImageUrl = amazonS3Manager.uploadFile(
+		String newProfileImageUrl = amazonS3Manager.uploadFile(
 			amazonS3Manager.generateProfileKeyName(),
-			profileImage
+			newProfileImage
 		);
 
-		amazonS3Manager.deleteFile(member.getProfileImageUrl());
-		member.updateProfileImageUrl(profileImageUrl);
+		String profileImageUrl = member.getProfileImageUrl();
+		if (profileImageUrl != null && !profileImageUrl.isEmpty()) {
+			amazonS3Manager.deleteFile(profileImageUrl);
+		}
+		member.updateProfileImageUrl(newProfileImageUrl);
 
 		return MemberConverter.toUpdateMemberResponseDTO(member);
 	}

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.example.gak.domain.member.converter.MemberConverter;
+import com.example.gak.domain.member.dto.MemberRequestDTO;
 import com.example.gak.domain.member.dto.MemberResponseDTO;
 import com.example.gak.domain.member.entity.Member;
 import com.example.gak.domain.member.repository.MemberRepository;
@@ -46,8 +47,7 @@ public class MemberCommandService {
 	}
 
 	public void markFirstLoginComplete(Long memberId) {
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
+		Member member = getMember(memberId);
 
 		if (member.isFirstLogin()) {
 			member.markLoginDone();
@@ -55,8 +55,7 @@ public class MemberCommandService {
 	}
 
 	public MemberResponseDTO.UpdateMemberResponseDTO updateProfileImage(Long memberId, MultipartFile profileImage) {
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
+		Member member = getMember(memberId);
 
 		if (profileImage == null) {
 			return MemberConverter.toUpdateMemberResponseDTO(member);
@@ -71,5 +70,20 @@ public class MemberCommandService {
 		member.updateProfileImageUrl(profileImageUrl);
 
 		return MemberConverter.toUpdateMemberResponseDTO(member);
+	}
+
+	public MemberResponseDTO.UpdateMemberResponseDTO updateNickname(
+		Long memberId,
+		MemberRequestDTO.UpdateMemberNicknameRequestDTO request
+	) {
+		Member member = getMember(memberId);
+		member.updateNickname(request.getNickname());
+
+		return MemberConverter.toUpdateMemberResponseDTO(member);
+	}
+
+	private Member getMember(Long memberId) {
+		return memberRepository.findById(memberId)
+			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -2,11 +2,15 @@ package com.example.gak.domain.member.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.example.gak.domain.member.converter.MemberConverter;
+import com.example.gak.domain.member.dto.MemberResponseDTO;
 import com.example.gak.domain.member.entity.Member;
 import com.example.gak.domain.member.repository.MemberRepository;
 import com.example.gak.global.apiPayload.code.GeneralErrorCode;
 import com.example.gak.global.apiPayload.exception.GeneralException;
+import com.example.gak.global.aws.AmazonS3Manager;
 import com.example.gak.global.security.oauth2.dto.OAuth2MemberDto;
 
 import lombok.RequiredArgsConstructor;
@@ -17,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberCommandService {
 
 	private final MemberRepository memberRepository;
+	private final AmazonS3Manager amazonS3Manager;
 
 	public Long synchronize(OAuth2MemberDto oAuth2MemberDto) {
 		return memberRepository.findBySocialProviderAndProviderId(
@@ -47,5 +52,24 @@ public class MemberCommandService {
 		if (member.isFirstLogin()) {
 			member.markLoginDone();
 		}
+	}
+
+	public MemberResponseDTO.UpdateMemberResponseDTO updateProfileImage(Long memberId, MultipartFile profileImage) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
+
+		if (profileImage == null) {
+			return MemberConverter.toUpdateMemberResponseDTO(member);
+		}
+
+		String profileImageUrl = amazonS3Manager.uploadFile(
+			amazonS3Manager.generateProfileKeyName(),
+			profileImage
+		);
+
+		amazonS3Manager.deleteFile(member.getProfileImageUrl());
+		member.updateProfileImageUrl(profileImageUrl);
+
+		return MemberConverter.toUpdateMemberResponseDTO(member);
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberQueryService.java
@@ -3,6 +3,7 @@ package com.example.gak.domain.member.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.gak.domain.member.converter.MemberConverter;
 import com.example.gak.domain.member.dto.MemberResponseDTO;
 import com.example.gak.domain.member.entity.Member;
 import com.example.gak.domain.member.repository.MemberRepository;
@@ -18,19 +19,10 @@ public class MemberQueryService {
 
 	private final MemberRepository memberRepository;
 
-	public MemberResponseDTO getMember(Long memberId) {
+	public MemberResponseDTO.GetMemberResponseDTO getMember(Long memberId) {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
 
-		return MemberResponseDTO.builder()
-			.id(member.getId())
-			.nickname(member.getNickname())
-			.profileImageUrl(member.getProfileImageUrl())
-			.bio(member.getBio())
-			.firstInterestCategory(member.getFirstInterestCategory())
-			.secondInterestCategory(member.getSecondInterestCategory())
-			.thirdInterestCategory(member.getThirdInterestCategory())
-			.firstLogin(member.isFirstLogin())
-			.build();
+		return MemberConverter.toGetMemberResponseDTO(member);
 	}
 }


### PR DESCRIPTION
## 작업 내용

- 회원 프로필 이미지 수정 API 구현
  - 이미지가 null인 경우 로직을 진행하지 않고 기존 정보 그대로 반환
- 회원 닉네임 수정 API 구현
  - 닉네임은 2~12자만 허용
  - 닉네임은 null, "", " ", 허용 X
  - 닉네임은 한글, 영어, 숫자만 가능
- 회원 관심 카테고리 수정 API 구현
  - 관심 카테고리는 null 허용
- 회원 엔티티 내부에 getDisplayNickname() 구현 (ex - 각 잡은 호랑이 `#1`)

## 참고 사항

- 닉네임 수정 로직은 현재 프론트에서 닉네임 값만을 전달 받는 형태(태그가 붙지 않음)인데, 추후에 랜덤 닉네임 생성 로직을 서버에서 담당하거나, PK 조회 로직이 추가되는 등의 변경 사항이 있을 수 있습니다.

## 연관 이슈

> close #41 


<br>