### PR TITLE
feat: 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/example/gak/domain/chatmessage/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/gak/domain/chatmessage/repository/ChatMessageRepository.java
@@ -1,0 +1,10 @@
+package com.example.gak.domain.chatmessage.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.gak.domain.chatmessage.entity.ChatMessage;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+	void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/example/gak/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/gak/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.example.gak.domain.member.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -66,5 +67,12 @@ public class MemberController {
 		return ApiResponse.onSuccess(
 			memberCommandService.updateInterestCategories(oAuth2User.getMemberId(), request)
 		);
+	}
+
+	@DeleteMapping("/me")
+	public ApiResponse<Void> deleteMember(@AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+		memberCommandService.deleteMember(oAuth2User.getMemberId());
+
+		return ApiResponse.onSuccess(null);
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/entity/Member.java
+++ b/src/main/java/com/example/gak/domain/member/entity/Member.java
@@ -76,7 +76,7 @@ public class Member extends BaseEntity {
 	}
 
 	public void markLoginDone() {
-		firstLogin = false;
+		this.firstLogin = false;
 	}
 
 	public void updateProfileImageUrl(String profileImageUrl) {
@@ -102,6 +102,6 @@ public class Member extends BaseEntity {
 	}
 
 	public void activate() {
-		deleted = false;
+		this.deleted = false;
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/entity/Member.java
+++ b/src/main/java/com/example/gak/domain/member/entity/Member.java
@@ -47,6 +47,8 @@ public class Member extends BaseEntity {
 
 	private boolean firstLogin;
 
+	private boolean deleted;
+
 	public Member(
 		String nickname,
 		String profileImageUrl,
@@ -66,6 +68,7 @@ public class Member extends BaseEntity {
 		this.socialProvider = socialProvider;
 		this.providerId = providerId;
 		this.firstLogin = true;
+		this.deleted = false;
 	}
 
 	public String getDisplayNickname() {
@@ -92,5 +95,9 @@ public class Member extends BaseEntity {
 		this.firstInterestCategory = firstInterestCategory;
 		this.secondInterestCategory = secondInterestCategory;
 		this.thirdInterestCategory = thirdInterestCategory;
+	}
+
+	public void delete() {
+		this.deleted = true;
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/entity/Member.java
+++ b/src/main/java/com/example/gak/domain/member/entity/Member.java
@@ -100,4 +100,8 @@ public class Member extends BaseEntity {
 	public void delete() {
 		this.deleted = true;
 	}
+
+	public void activate() {
+		deleted = false;
+	}
 }

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -122,6 +122,10 @@ public class MemberCommandService {
 	}
 
 	public void deleteMember(Long memberId) {
+		if (sessionRoomRepository.existsByMemberIdAndStatusNot(memberId, SessionRoomStatus.COMPLETED)) {
+			throw new GeneralException(GeneralErrorCode.HAS_ACTIVE_SESSION);
+		}
+
 		Member member = getMember(memberId);
 
 		recordRepository.deleteByMemberId(memberId);
@@ -129,15 +133,14 @@ public class MemberCommandService {
 		sessionRoomMemberRepository.deleteByMemberId(memberId);
 
 		List<Task> tasks = taskRepository.findByMemberId(memberId);
-		List<Long> taskIds = tasks.stream()
-			.map(Task::getId)
-			.toList();
-		subTaskRepository.deleteByTaskIdIn(taskIds);
-		taskRepository.deleteAllInBatch(tasks);
-
-		if (sessionRoomRepository.existsByMemberIdAndStatusNot(memberId, SessionRoomStatus.COMPLETED)) {
-			throw new GeneralException(GeneralErrorCode.HAS_ACTIVE_SESSION);
+		if (!tasks.isEmpty()) {
+			List<Long> taskIds = tasks.stream()
+				.map(Task::getId)
+				.toList();
+			subTaskRepository.deleteByTaskIdIn(taskIds);
+			taskRepository.deleteAllInBatch(tasks);
 		}
+
 		sessionRoomRepository.deleteByMemberId(memberId);
 
 		member.delete();

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -1,14 +1,24 @@
 package com.example.gak.domain.member.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.example.gak.domain.chatmessage.repository.ChatMessageRepository;
 import com.example.gak.domain.member.converter.MemberConverter;
 import com.example.gak.domain.member.dto.MemberRequestDTO;
 import com.example.gak.domain.member.dto.MemberResponseDTO;
 import com.example.gak.domain.member.entity.Member;
 import com.example.gak.domain.member.repository.MemberRepository;
+import com.example.gak.domain.record.repository.RecordRepository;
+import com.example.gak.domain.session.entity.enums.SessionRoomStatus;
+import com.example.gak.domain.session.repository.SessionRoomMemberRepository;
+import com.example.gak.domain.session.repository.SessionRoomRepository;
+import com.example.gak.domain.subtask.repository.SubTaskRepository;
+import com.example.gak.domain.task.entity.Task;
+import com.example.gak.domain.task.repository.TaskRepository;
 import com.example.gak.global.apiPayload.code.GeneralErrorCode;
 import com.example.gak.global.apiPayload.exception.GeneralException;
 import com.example.gak.global.aws.AmazonS3Manager;
@@ -23,6 +33,13 @@ public class MemberCommandService {
 
 	private final MemberRepository memberRepository;
 	private final AmazonS3Manager amazonS3Manager;
+
+	private final RecordRepository recordRepository;
+	private final ChatMessageRepository chatMessageRepository;
+	private final TaskRepository taskRepository;
+	private final SubTaskRepository subTaskRepository;
+	private final SessionRoomRepository sessionRoomRepository;
+	private final SessionRoomMemberRepository sessionRoomMemberRepository;
 
 	public Long synchronize(OAuth2MemberDto oAuth2MemberDto) {
 		return memberRepository.findBySocialProviderAndProviderId(
@@ -97,6 +114,28 @@ public class MemberCommandService {
 		);
 
 		return MemberConverter.toUpdateMemberResponseDTO(member);
+	}
+
+	public void deleteMember(Long memberId) {
+		Member member = getMember(memberId);
+
+		recordRepository.deleteByMemberId(memberId);
+		chatMessageRepository.deleteByMemberId(memberId);
+		sessionRoomMemberRepository.deleteByMemberId(memberId);
+
+		List<Task> tasks = taskRepository.findByMemberId(memberId);
+		List<Long> taskIds = tasks.stream()
+			.map(Task::getId)
+			.toList();
+		subTaskRepository.deleteByTaskIdIn(taskIds);
+		taskRepository.deleteAllInBatch(tasks);
+
+		if (sessionRoomRepository.existsByMemberIdAndStatusNot(memberId, SessionRoomStatus.COMPLETED)) {
+			throw new GeneralException(GeneralErrorCode.HAS_ACTIVE_SESSION);
+		}
+		sessionRoomRepository.deleteByMemberId(memberId);
+
+		member.delete();
 	}
 
 	private Member getMember(Long memberId) {

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -46,7 +46,12 @@ public class MemberCommandService {
 				oAuth2MemberDto.getProvider(),
 				oAuth2MemberDto.getProviderId()
 			)
-			.map(Member::getId)
+			.map(member -> {
+				if (member.isDeleted()) {
+					member.activate();
+				}
+				return member.getId();
+			})
 			.orElseGet(() -> {
 					Member member = new Member(
 						oAuth2MemberDto.getNickname(),

--- a/src/main/java/com/example/gak/domain/record/repository/RecordRepository.java
+++ b/src/main/java/com/example/gak/domain/record/repository/RecordRepository.java
@@ -1,0 +1,10 @@
+package com.example.gak.domain.record.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.gak.domain.record.entity.Record;
+
+public interface RecordRepository extends JpaRepository<Record, Long> {
+
+	void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/example/gak/domain/session/repository/SessionRoomMemberRepository.java
+++ b/src/main/java/com/example/gak/domain/session/repository/SessionRoomMemberRepository.java
@@ -1,0 +1,10 @@
+package com.example.gak.domain.session.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.gak.domain.session.entity.SessionRoomMember;
+
+public interface SessionRoomMemberRepository extends JpaRepository<SessionRoomMember, Long> {
+
+	void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/example/gak/domain/session/repository/SessionRoomRepository.java
+++ b/src/main/java/com/example/gak/domain/session/repository/SessionRoomRepository.java
@@ -1,10 +1,15 @@
 package com.example.gak.domain.session.repository;
 
-import com.example.gak.domain.session.entity.SessionRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface SessionRoomRepository extends JpaRepository<SessionRoom, Long>,
-        JpaSpecificationExecutor<SessionRoom> {
+import com.example.gak.domain.session.entity.SessionRoom;
+import com.example.gak.domain.session.entity.enums.SessionRoomStatus;
 
+public interface SessionRoomRepository extends JpaRepository<SessionRoom, Long>,
+	JpaSpecificationExecutor<SessionRoom> {
+
+	void deleteByMemberId(Long memberId);
+
+	boolean existsByMemberIdAndStatusNot(Long memberId, SessionRoomStatus status);
 }

--- a/src/main/java/com/example/gak/domain/subtask/repository/SubTaskRepository.java
+++ b/src/main/java/com/example/gak/domain/subtask/repository/SubTaskRepository.java
@@ -1,0 +1,19 @@
+package com.example.gak.domain.subtask.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.example.gak.domain.subtask.entity.SubTask;
+
+public interface SubTaskRepository extends JpaRepository<SubTask, Long> {
+
+	@Modifying
+	@Query("""
+		DELETE FROM SubTask s WHERE s.task.id IN :taskIds
+		""")
+	void deleteByTaskIdIn(@Param("taskIds") List<Long> taskIds);
+}

--- a/src/main/java/com/example/gak/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/example/gak/domain/task/repository/TaskRepository.java
@@ -1,0 +1,12 @@
+package com.example.gak.domain.task.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.gak.domain.task.entity.Task;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+
+	List<Task> findByMemberId(Long memberId);
+}

--- a/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
@@ -26,6 +26,7 @@ public enum GeneralErrorCode implements BaseErrorCode {
 
 	// 회원 관련
 	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "MEMBER404_1", "존재하지 않는 회원입니다."),
+	HAS_ACTIVE_SESSION(HttpStatus.CONFLICT, "MEMBER409_1", "완료되지 않은 세션이 존재하여 탈퇴할 수 없습니다."),
 
 	// AWS S3 관련
 	S3_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500_1", "S3 업로드에 실패했습니다."),


### PR DESCRIPTION
## 작업 내용

- 회원 엔티티는 소프트 딜리트 (deleted 속성 추가)
- 연관된 나머지 엔티티는 하드 딜리트
- 만약 본인이 생성한 세션 중 완료 상태가 아닌 세션이 있다면 에러 응답 (모두 완료된 상태여야 탈퇴 가능)
- 회원 동기화(로그인 과정에 포함된 로직) 시 deleted 상태가 true면 다시 활성화하도록 로직 수정

## 참고 사항

- 우선은 단순하게 삭제 대상 엔티티의 리포지토리들을 MemberCommandService에 주입했습니다.
- 소셜 제공자와의 연결 해제는 추후에 진행하려 합니다.

## 연관 이슈

> close #43