### PR TITLE
feat: 세션 생성 API 구현

### DIFF
--- a/src/main/java/com/example/gak/domain/session/controller/SessionController.java
+++ b/src/main/java/com/example/gak/domain/session/controller/SessionController.java
@@ -77,7 +77,7 @@ public class SessionController {
     public ApiResponse<SessionResponseDTO.CreateSessionResponseDTO> createSession(
             @AuthenticationPrincipal CustomOAuth2User oAuth2User,
             @RequestPart("request") @Valid SessionRequestDTO.CreateSessionRequestDTO request,
-            @RequestPart(value = "images", required = false) MultipartFile image
+            @RequestPart(value = "image", required = false) MultipartFile image
     ){
         Long memberId = oAuth2User.getMemberId();
         SessionRoom sessionRoom = sessionCommandService.createSession(request, image, memberId);

--- a/src/main/java/com/example/gak/domain/session/controller/SessionController.java
+++ b/src/main/java/com/example/gak/domain/session/controller/SessionController.java
@@ -10,13 +10,11 @@ import com.example.gak.domain.session.dto.SessionResponseDTO;
 import com.example.gak.domain.session.service.SessionCommandService;
 import com.example.gak.domain.session.service.SessionQueryService;
 import com.example.gak.global.apiPayload.ApiResponse;
-import com.example.gak.global.security.jwt.JwtProvider;
 import com.example.gak.global.security.oauth2.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -34,9 +32,6 @@ public class SessionController {
 
     private final SessionQueryService sessionQueryService;
     private final SessionCommandService sessionCommandService;
-
-    @Autowired
-    private JwtProvider jwtProvider;
 
     @Operation(summary = "세션 목록 조회 API")
     @GetMapping

--- a/src/main/java/com/example/gak/domain/session/controller/SessionController.java
+++ b/src/main/java/com/example/gak/domain/session/controller/SessionController.java
@@ -7,7 +7,7 @@ import com.example.gak.domain.session.enums.DurationRange;
 import com.example.gak.domain.session.enums.SessionSort;
 import com.example.gak.domain.session.enums.TimeSlot;
 import com.example.gak.domain.session.dto.SessionResponseDTO;
-import com.example.gak.domain.session.service.SessionCommendService;
+import com.example.gak.domain.session.service.SessionCommandService;
 import com.example.gak.domain.session.service.SessionQueryService;
 import com.example.gak.global.apiPayload.ApiResponse;
 import com.example.gak.global.security.jwt.JwtProvider;
@@ -22,7 +22,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -34,7 +33,7 @@ import static com.example.gak.domain.session.converter.SessionConverter.toCreate
 public class SessionController {
 
     private final SessionQueryService sessionQueryService;
-    private final SessionCommendService sessionCommendService;
+    private final SessionCommandService sessionCommandService;
 
     @Autowired
     private JwtProvider jwtProvider;
@@ -86,7 +85,7 @@ public class SessionController {
             @RequestPart(value = "images", required = false) MultipartFile image
     ){
         Long memberId = oAuth2User.getMemberId();
-        SessionRoom sessionRoom = sessionCommendService.createSession(request, image, memberId);
+        SessionRoom sessionRoom = sessionCommandService.createSession(request, image, memberId);
         return ApiResponse.onSuccess(toCreateSessionResponseDTO(sessionRoom));
     }
 }

--- a/src/main/java/com/example/gak/domain/session/controller/SessionController.java
+++ b/src/main/java/com/example/gak/domain/session/controller/SessionController.java
@@ -1,19 +1,32 @@
 package com.example.gak.domain.session.controller;
 
 import com.example.gak.domain.common.entity.enums.SessionCategory;
+import com.example.gak.domain.session.dto.SessionRequestDTO;
+import com.example.gak.domain.session.entity.SessionRoom;
 import com.example.gak.domain.session.enums.DurationRange;
 import com.example.gak.domain.session.enums.SessionSort;
 import com.example.gak.domain.session.enums.TimeSlot;
 import com.example.gak.domain.session.dto.SessionResponseDTO;
+import com.example.gak.domain.session.service.SessionCommendService;
 import com.example.gak.domain.session.service.SessionQueryService;
 import com.example.gak.global.apiPayload.ApiResponse;
+import com.example.gak.global.security.jwt.JwtProvider;
+import com.example.gak.global.security.oauth2.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
+
+import static com.example.gak.domain.session.converter.SessionConverter.toCreateSessionResponseDTO;
 
 @RestController
 @RequestMapping("/api/v1/sessions")
@@ -21,6 +34,10 @@ import java.util.List;
 public class SessionController {
 
     private final SessionQueryService sessionQueryService;
+    private final SessionCommendService sessionCommendService;
+
+    @Autowired
+    private JwtProvider jwtProvider;
 
     @Operation(summary = "세션 목록 조회 API")
     @GetMapping
@@ -59,5 +76,17 @@ public class SessionController {
                         size
                 )
         );
+    }
+
+    @Operation(summary = "세션 생성 API")
+    @PostMapping(path = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<SessionResponseDTO.CreateSessionResponseDTO> createSession(
+            @AuthenticationPrincipal CustomOAuth2User oAuth2User,
+            @RequestPart("request") @Valid SessionRequestDTO.CreateSessionRequestDTO request,
+            @RequestPart(value = "images", required = false) MultipartFile image
+    ){
+        Long memberId = oAuth2User.getMemberId();
+        SessionRoom sessionRoom = sessionCommendService.createSession(request, image, memberId);
+        return ApiResponse.onSuccess(toCreateSessionResponseDTO(sessionRoom));
     }
 }

--- a/src/main/java/com/example/gak/domain/session/converter/SessionConverter.java
+++ b/src/main/java/com/example/gak/domain/session/converter/SessionConverter.java
@@ -34,4 +34,12 @@ public class SessionConverter {
                 .sessions(sessionCards)
                 .build();
     }
+
+    public static SessionResponseDTO.CreateSessionResponseDTO toCreateSessionResponseDTO(
+            SessionRoom sessionRoom
+    ){
+        return SessionResponseDTO.CreateSessionResponseDTO.builder()
+                .createdSessionId(sessionRoom.getId())
+                .build();
+    }
 }

--- a/src/main/java/com/example/gak/domain/session/converter/SessionConverter.java
+++ b/src/main/java/com/example/gak/domain/session/converter/SessionConverter.java
@@ -10,6 +10,7 @@ public class SessionConverter {
 
     public static SessionResponseDTO.SessionCardResponseDTO toSessionCardResponseDTO(SessionRoom sessionRoom) {
         return SessionResponseDTO.SessionCardResponseDTO.builder()
+                .sessionId(sessionRoom.getId())
                 .category(sessionRoom.getCategory().getDisplayName())
                 .title(sessionRoom.getTitle())
                 .hostNickname(sessionRoom.getMember().getNickname())

--- a/src/main/java/com/example/gak/domain/session/dto/SessionRequestDTO.java
+++ b/src/main/java/com/example/gak/domain/session/dto/SessionRequestDTO.java
@@ -1,0 +1,54 @@
+package com.example.gak.domain.session.dto;
+
+import com.example.gak.domain.common.entity.enums.SessionCategory;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+import jakarta.validation.constraints.*;
+import java.time.LocalDateTime;
+
+public class SessionRequestDTO {
+
+    @Getter
+    @Builder
+    public static class CreateSessionRequestDTO{
+        @NotBlank
+        @Size(max = 20)
+        private String title;
+
+        @NotBlank
+        @Size(max = 50)
+        private String summary;
+
+        @NotBlank
+        @Size(max = 100)
+        private String notice;
+
+        @NotNull
+        private SessionCategory category;
+
+        @NotNull
+        @Future
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+        private LocalDateTime startTime;
+
+        @NotNull
+        @Positive
+        private Integer sessionDurationMinutes;
+
+        @NotNull
+        @Positive
+        private Integer maxParticipants;
+
+        @Min(0)
+        private Integer requiredFocusRate = 0;
+
+        @Min(0)
+        private Integer requiredAchievementRate = 0;
+    }
+}

--- a/src/main/java/com/example/gak/domain/session/dto/SessionResponseDTO.java
+++ b/src/main/java/com/example/gak/domain/session/dto/SessionResponseDTO.java
@@ -25,11 +25,11 @@ public class SessionResponseDTO {
     @Builder
     @Getter
     public static class SessionCardResponseListDTO {
-        Integer listSize;
-        Integer totalPage;
-        Long totalElements;
-        Boolean isFirst;
-        Boolean isLast;
-        List<SessionCardResponseDTO> sessions;
+        private Integer listSize;
+        private Integer totalPage;
+        private Long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
+        private List<SessionCardResponseDTO> sessions;
     }
 }

--- a/src/main/java/com/example/gak/domain/session/dto/SessionResponseDTO.java
+++ b/src/main/java/com/example/gak/domain/session/dto/SessionResponseDTO.java
@@ -32,4 +32,10 @@ public class SessionResponseDTO {
         private Boolean isLast;
         private List<SessionCardResponseDTO> sessions;
     }
+
+    @Builder
+    @Getter
+    public static class CreateSessionResponseDTO {
+        Long createdSessionId;
+    }
 }

--- a/src/main/java/com/example/gak/domain/session/dto/SessionResponseDTO.java
+++ b/src/main/java/com/example/gak/domain/session/dto/SessionResponseDTO.java
@@ -10,6 +10,7 @@ public class SessionResponseDTO {
     @Builder
     @Getter
     public static class SessionCardResponseDTO{
+        private Long sessionId;
         private String category;
         private String title;
         private String hostNickname;

--- a/src/main/java/com/example/gak/domain/session/entity/SessionRoom.java
+++ b/src/main/java/com/example/gak/domain/session/entity/SessionRoom.java
@@ -81,6 +81,8 @@ public class SessionRoom extends BaseEntity {
 		Integer durationMinutes,
 		Integer maxCapacity,
 		SessionRoomStatus status,
+		Integer requiredFocusRate,
+		Integer requiredAchievementRate,
 		Member member
 	) {
 		this.category = category;
@@ -92,6 +94,8 @@ public class SessionRoom extends BaseEntity {
 		this.durationMinutes = durationMinutes;
 		this.maxCapacity = maxCapacity;
 		this.status = status;
+		this.requiredFocusRate = requiredFocusRate;
+		this.requiredAchievementRate = requiredAchievementRate;
 		this.member = member;
 	}
 }

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -9,6 +9,7 @@ import com.example.gak.domain.session.repository.SessionRoomRepository;
 import com.example.gak.global.apiPayload.code.GeneralErrorCode;
 import com.example.gak.global.apiPayload.exception.GeneralException;
 import com.example.gak.global.aws.AmazonS3Manager;
+import com.example.gak.global.validator.ImageFileValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,7 @@ public class SessionCommandService {
     private final MemberRepository memberRepository;
     private final SessionRoomRepository sessionRoomRepository;
     private final AmazonS3Manager amazonS3Manager;
+    private final ImageFileValidator imageFileValidator;
 
     public SessionRoom createSession(
             SessionRequestDTO.CreateSessionRequestDTO request,
@@ -42,6 +44,8 @@ public class SessionCommandService {
 
         String imageUrl;
         if(image != null && !image.isEmpty()) {
+            imageFileValidator.validate(image);
+
             String keyName = amazonS3Manager.generateSessionThumbnailKeyName();
             imageUrl = amazonS3Manager.uploadFile(keyName, image);
         }else{

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -11,13 +11,15 @@ import com.example.gak.global.apiPayload.exception.GeneralException;
 import com.example.gak.global.aws.AmazonS3Manager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
-public class SessionCommendService {
+public class SessionCommandService {
 
     private static final long MIN_START_MINUTES = 5;
 

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -58,6 +58,8 @@ public class SessionCommandService {
                 request.getSessionDurationMinutes(),
                 request.getMaxParticipants(),
                 SessionRoomStatus.WAITING,
+                request.getRequiredFocusRate(),
+                request.getRequiredAchievementRate(),
                 member
         );
         sessionRoomRepository.save(newSessionRoom);

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -41,7 +41,7 @@ public class SessionCommandService {
         }
 
         String imageUrl;
-        if(!image.isEmpty()) {
+        if(image != null && !image.isEmpty()) {
             String keyName = amazonS3Manager.generateSessionThumbnailKeyName();
             imageUrl = amazonS3Manager.uploadFile(keyName, image);
         }else{

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommendService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommendService.java
@@ -1,0 +1,64 @@
+package com.example.gak.domain.session.service;
+
+import com.example.gak.domain.member.entity.Member;
+import com.example.gak.domain.member.repository.MemberRepository;
+import com.example.gak.domain.session.dto.SessionRequestDTO;
+import com.example.gak.domain.session.entity.SessionRoom;
+import com.example.gak.domain.session.entity.enums.SessionRoomStatus;
+import com.example.gak.domain.session.repository.SessionRoomRepository;
+import com.example.gak.global.apiPayload.code.GeneralErrorCode;
+import com.example.gak.global.apiPayload.exception.GeneralException;
+import com.example.gak.global.aws.AmazonS3Manager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class SessionCommendService {
+
+    private static final long MIN_START_MINUTES = 5;
+
+    private final MemberRepository memberRepository;
+    private final SessionRoomRepository sessionRoomRepository;
+    private final AmazonS3Manager amazonS3Manager;
+
+    public SessionRoom createSession(
+            SessionRequestDTO.CreateSessionRequestDTO request,
+            MultipartFile image,
+            Long memberId
+    ){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.MEMBER_NOT_FOUND));
+
+        LocalDateTime minAllowedStartTime  = LocalDateTime.now().plusMinutes(MIN_START_MINUTES);
+        if (request.getStartTime().isBefore(minAllowedStartTime )) {
+            throw new GeneralException(GeneralErrorCode.SESSION_START_TIME_TOO_SOON);
+        }
+
+        String imageUrl;
+        if(!image.isEmpty()) {
+            String keyName = amazonS3Manager.generateSessionThumbnailKeyName();
+            imageUrl = amazonS3Manager.uploadFile(keyName, image);
+        }else{
+            imageUrl = ""; // 기본 이미지 디자인 완성 시 URL 추가
+        }
+
+        SessionRoom newSessionRoom =  new SessionRoom(
+                request.getCategory(),
+                request.getTitle(),
+                request.getSummary(),
+                request.getNotice(),
+                imageUrl,
+                request.getStartTime(),
+                request.getSessionDurationMinutes(),
+                request.getMaxParticipants(),
+                SessionRoomStatus.WAITING,
+                member
+        );
+        sessionRoomRepository.save(newSessionRoom);
+        return newSessionRoom;
+    }
+}

--- a/src/main/java/com/example/gak/domain/session/service/SessionQueryService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionQueryService.java
@@ -14,14 +14,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
 
-import static com.example.gak.domain.session.enums.SessionSort.*;
-
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class SessionQueryService {
 
     private final SessionRoomRepository sessionRoomRepository;

--- a/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
@@ -33,7 +33,13 @@ public enum GeneralErrorCode implements BaseErrorCode {
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "존재하지 않는 사용자입니다."),
 
 	// 세션 관련
-	SESSION_START_TIME_TOO_SOON(HttpStatus.BAD_REQUEST, "SESSION400_1", "세션 시작 시간은 현재 시각 기준 5분 이후로 설정해야 합니다.");
+	SESSION_START_TIME_TOO_SOON(HttpStatus.BAD_REQUEST, "SESSION400_1", "세션 시작 시간은 현재 시각 기준 5분 이후로 설정해야 합니다."),
+
+	// 파일 관련
+	INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "FILE400_1", "허용되지 않은 이미지 형식입니다."),
+	FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "FILE400_2", "이미지 파일 크기가 너무 큽니다."),
+	FILE_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "FILE400_3", "파일 검증에 실패했습니다.");
+
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
@@ -27,7 +27,13 @@ public enum GeneralErrorCode implements BaseErrorCode {
 	// AWS S3 관련
 	S3_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500_1", "S3 업로드에 실패했습니다."),
 	S3_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500_2", "S3 파일 삭제에 실패했습니다."),
-	S3_DOWNLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500_3", "S3 파일 조회에 실패했습니다.");
+	S3_DOWNLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500_3", "S3 파일 조회에 실패했습니다."),
+
+	// 회원 관련
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "존재하지 않는 사용자입니다."),
+
+	// 세션 관련
+	SESSION_START_TIME_TOO_SOON(HttpStatus.BAD_REQUEST, "SESSION400_1", "세션 시작 시간은 현재 시각 기준 5분 이후로 설정해야 합니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/example/gak/global/configuration/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/example/gak/global/configuration/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,31 @@
+package com.example.gak.global.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/com/example/gak/global/validator/ImageFileValidator.java
+++ b/src/main/java/com/example/gak/global/validator/ImageFileValidator.java
@@ -1,0 +1,31 @@
+package com.example.gak.global.validator;
+
+import com.example.gak.global.apiPayload.code.GeneralErrorCode;
+import com.example.gak.global.apiPayload.exception.GeneralException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Component
+public class ImageFileValidator {
+
+    private static final List<String> ALLOWED_CONTENT_TYPES = List.of(
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+    );
+
+    private static final long MAX_SIZE = 5 * 1024 * 1024;
+
+    public void validate(MultipartFile image) {
+        if (image.getSize() > MAX_SIZE) {
+            throw new GeneralException(GeneralErrorCode.FILE_TOO_LARGE);
+        }
+
+        String contentType = image.getContentType();
+        if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType)) {
+            throw new GeneralException(GeneralErrorCode.INVALID_IMAGE_TYPE);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,6 +5,11 @@ spring:
     password: ${DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 5MB
+
   data:
     redis:
       host: ${REDIS_HOST}


### PR DESCRIPTION
## 작업 내용

> 세션 생성 API를 구현하였습니다.

## 참고 사항

> - 세션 썸네일 디폴트 이미지 디자인 제작 이후 실제 이미지 url로 변경됩니다.
> - 썸네일 이미지 업로드 시 최대 5MB로 제한해두었습니다.
> - 이미지 파일인지에 대한 검증을 위해 ImageFileValidator 클래스가 추가되었습니다. 개발 단계에서 이미지 파일에 대한 검증은 Content-Type을 기준으로만 진행합니다.

## 연관 이슈

> close #40

<br>