### PR TITLE
feat: OAuth2 로그인 프로세스 보완

### DIFF
--- a/src/main/java/com/example/gak/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/gak/domain/auth/service/AuthService.java
@@ -55,7 +55,7 @@ public class AuthService {
 
 		String storedRefreshToken = jwtService.getRefreshToken(memberId);
 		if (storedRefreshToken == null) {
-			throw new GeneralException(GeneralErrorCode.NOT_FOUND_REFRESH_TOKEN);
+			throw new GeneralException(GeneralErrorCode.REFRESH_TOKEN_NOT_FOUND);
 		}
 		if (!storedRefreshToken.equals(refreshToken)) {
 			throw new GeneralException(GeneralErrorCode.REFRESH_TOKEN_MISMATCH);

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -1,6 +1,7 @@
 package com.example.gak.domain.member.service;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +13,7 @@ import com.example.gak.domain.member.dto.MemberRequestDTO;
 import com.example.gak.domain.member.dto.MemberResponseDTO;
 import com.example.gak.domain.member.entity.Member;
 import com.example.gak.domain.member.repository.MemberRepository;
+import com.example.gak.domain.record.entity.Record;
 import com.example.gak.domain.record.repository.RecordRepository;
 import com.example.gak.domain.session.entity.enums.SessionRoomStatus;
 import com.example.gak.domain.session.repository.SessionRoomMemberRepository;
@@ -42,30 +44,36 @@ public class MemberCommandService {
 	private final SessionRoomMemberRepository sessionRoomMemberRepository;
 
 	public Long synchronize(OAuth2MemberDto oAuth2MemberDto) {
-		return memberRepository.findBySocialProviderAndProviderId(
+		Optional<Member> optionalMember = memberRepository.findBySocialProviderAndProviderId(
+			oAuth2MemberDto.getProvider(),
+			oAuth2MemberDto.getProviderId()
+		);
+
+		if (optionalMember.isEmpty()) {
+			Member member = new Member(
+				oAuth2MemberDto.getNickname(),
+				oAuth2MemberDto.getProfileImage().orElse(""), // 기본 이미지 디자인 완성 시 URL 추가
+				null,
+				null,
+				null,
+				null,
 				oAuth2MemberDto.getProvider(),
 				oAuth2MemberDto.getProviderId()
-			)
-			.map(member -> {
-				if (member.isDeleted()) {
-					member.activate();
-				}
-				return member.getId();
-			})
-			.orElseGet(() -> {
-					Member member = new Member(
-						oAuth2MemberDto.getNickname(),
-						oAuth2MemberDto.getProfileImage().orElse(""), // 기본 이미지 디자인 완성 시 URL 추가
-						null,
-						null,
-						null,
-						null,
-						oAuth2MemberDto.getProvider(),
-						oAuth2MemberDto.getProviderId()
-					);
-					return memberRepository.save(member).getId();
-				}
 			);
+			Member persisted = memberRepository.save(member);
+
+			Record record = new Record(persisted);
+			recordRepository.save(record);
+
+			return persisted.getId();
+		}
+
+		Member member = optionalMember.get();
+		if (member.isDeleted()) {
+			member.activate();
+		}
+
+		return member.getId();
 	}
 
 	public void markFirstLoginComplete(Long memberId) {

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -131,7 +131,7 @@ public class MemberCommandService {
 
 	public void deleteMember(Long memberId) {
 		if (sessionRoomRepository.existsByMemberIdAndStatusNot(memberId, SessionRoomStatus.COMPLETED)) {
-			throw new GeneralException(GeneralErrorCode.HAS_ACTIVE_SESSION);
+			throw new GeneralException(GeneralErrorCode.MEMBER_HAS_ACTIVE_SESSION);
 		}
 
 		Member member = getMember(memberId);
@@ -156,6 +156,6 @@ public class MemberCommandService {
 
 	private Member getMember(Long memberId) {
 		return memberRepository.findById(memberId)
-			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
+			.orElseThrow(() -> new GeneralException(GeneralErrorCode.MEMBER_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberQueryService.java
@@ -21,7 +21,7 @@ public class MemberQueryService {
 
 	public MemberResponseDTO.GetMemberResponseDTO getMember(Long memberId) {
 		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
+			.orElseThrow(() -> new GeneralException(GeneralErrorCode.MEMBER_NOT_FOUND));
 
 		return MemberConverter.toGetMemberResponseDTO(member);
 	}

--- a/src/main/java/com/example/gak/domain/record/entity/Record.java
+++ b/src/main/java/com/example/gak/domain/record/entity/Record.java
@@ -56,35 +56,20 @@ public class Record extends BaseEntity {
 	@JoinColumn(name = "member_id", nullable = false, unique = true)
 	private Member member;
 
-	public Record(
-		long participationTime,
-		long focusedTime,
-		int completedSessionCount,
-		int totalTodoCount,
-		int achievedTodoCount,
-		int devSessionCount,
-		int designSessionCount,
-		int planningPmSessionCount,
-		int careerSelfDevSessionCount,
-		int studyReadingSessionCount,
-		int creativeSessionCount,
-		int teamProjectSessionCount,
-		int etcSessionCount,
-		Member member
-	) {
-		this.participationTime = participationTime;
-		this.focusedTime = focusedTime;
-		this.completedSessionCount = completedSessionCount;
-		this.totalTodoCount = totalTodoCount;
-		this.achievedTodoCount = achievedTodoCount;
-		this.devSessionCount = devSessionCount;
-		this.designSessionCount = designSessionCount;
-		this.planningPmSessionCount = planningPmSessionCount;
-		this.careerSelfDevSessionCount = careerSelfDevSessionCount;
-		this.studyReadingSessionCount = studyReadingSessionCount;
-		this.creativeSessionCount = creativeSessionCount;
-		this.teamProjectSessionCount = teamProjectSessionCount;
-		this.etcSessionCount = etcSessionCount;
+	public Record(Member member) {
+		this.participationTime = 0;
+		this.focusedTime = 0;
+		this.completedSessionCount = 0;
+		this.totalTodoCount = 0;
+		this.achievedTodoCount = 0;
+		this.devSessionCount = 0;
+		this.designSessionCount = 0;
+		this.planningPmSessionCount = 0;
+		this.careerSelfDevSessionCount = 0;
+		this.studyReadingSessionCount = 0;
+		this.creativeSessionCount = 0;
+		this.teamProjectSessionCount = 0;
+		this.etcSessionCount = 0;
 		this.member = member;
 	}
 

--- a/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
@@ -27,13 +27,9 @@ public enum GeneralErrorCode implements BaseErrorCode {
 	INVALID_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "AUTH401_2", "토큰 형식이 올바르지 않습니다."),
 	ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_3", "기한이 만료된 Access 토큰입니다."),
 	REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_4", "기한이 만료된 Refresh 토큰입니다."),
-	NOT_FOUND_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_5", "존재하지 않는 Refresh 토큰입니다."),
+	REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH401_5", "존재하지 않는 Refresh 토큰입니다."),
 	REFRESH_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH401_6", "Refresh 토큰이 전달되지 않았습니다."),
 	REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH401_7", "Refresh 토큰 정보가 일치하지 않습니다."),
-
-	// 회원 관련
-	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "MEMBER404_1", "존재하지 않는 회원입니다."),
-	HAS_ACTIVE_SESSION(HttpStatus.CONFLICT, "MEMBER409_1", "완료되지 않은 세션이 존재하여 탈퇴할 수 없습니다."),
 
 	// AWS S3 관련
 	S3_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500_1", "S3 업로드에 실패했습니다."),
@@ -42,6 +38,7 @@ public enum GeneralErrorCode implements BaseErrorCode {
 
 	// 회원 관련
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "존재하지 않는 사용자입니다."),
+	MEMBER_HAS_ACTIVE_SESSION(HttpStatus.CONFLICT, "MEMBER409_1", "완료되지 않은 세션이 존재하여 탈퇴할 수 없습니다."),
 
 	// 세션 관련
 	SESSION_START_TIME_TOO_SOON(HttpStatus.BAD_REQUEST, "SESSION400_1", "세션 시작 시간은 현재 시각 기준 5분 이후로 설정해야 합니다."),

--- a/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
@@ -14,15 +14,22 @@ public enum GeneralErrorCode implements BaseErrorCode {
 	_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 처리 중 오류가 발생했습니다."),
 	_BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400_1", "잘못된 요청입니다."),
 
+	// OAuth2 관련
+	OAUTH2_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "OAUTH401_1", "OAuth2 로그인에 실패했습니다."),
+	OAUTH2_ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "OAUTH401_2", "소셜 로그인 인증이 거부되었습니다."),
+	OAUTH2_PROVIDER_ERROR(HttpStatus.UNAUTHORIZED, "OAUTH401_3", "소셜 로그인 제공자 처리 중 오류가 발생했습니다."),
+	OAUTH2_INVALID_REQUEST(HttpStatus.UNAUTHORIZED, "OAUTH401_4", "OAuth2 요청이 올바르지 않습니다."),
+	OAUTH2_UNSUPPORTED_PROVIDER(HttpStatus.UNAUTHORIZED, "OAUTH401_5", "지원하지 않는 소셜 로그인 제공자입니다."),
+	OAUTH2_UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OAUTH500_1", "예상치 못한 오류가 발생했습니다."),
+
 	// 인증 관련
 	INVALID_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "AUTH401_1", "올바르지 않은 Authorization 헤더입니다."),
 	INVALID_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "AUTH401_2", "토큰 형식이 올바르지 않습니다."),
 	ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_3", "기한이 만료된 Access 토큰입니다."),
-	UNSUPPORTED_PROVIDER(HttpStatus.UNAUTHORIZED, "AUTH401_4", "지원하지 않는 소셜 로그인 제공자입니다."),
-	REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_5", "기한이 만료된 Refresh 토큰입니다."),
-	NOT_FOUND_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_6", "존재하지 않는 Refresh 토큰입니다."),
-	REFRESH_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH401_7", "Refresh 토큰이 전달되지 않았습니다."),
-	REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH401_8", "Refresh 토큰 정보가 일치하지 않습니다."),
+	REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_4", "기한이 만료된 Refresh 토큰입니다."),
+	NOT_FOUND_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_5", "존재하지 않는 Refresh 토큰입니다."),
+	REFRESH_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH401_6", "Refresh 토큰이 전달되지 않았습니다."),
+	REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH401_7", "Refresh 토큰 정보가 일치하지 않습니다."),
 
 	// 회원 관련
 	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "MEMBER404_1", "존재하지 않는 회원입니다."),
@@ -43,7 +50,6 @@ public enum GeneralErrorCode implements BaseErrorCode {
 	INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "FILE400_1", "허용되지 않은 이미지 형식입니다."),
 	FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "FILE400_2", "이미지 파일 크기가 너무 큽니다."),
 	FILE_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "FILE400_3", "파일 검증에 실패했습니다.");
-
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/example/gak/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/gak/global/security/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import com.example.gak.global.security.oauth2.CustomFailureHandler;
 import com.example.gak.global.security.oauth2.CustomOAuth2UserService;
 import com.example.gak.global.security.oauth2.CustomOidcUserService;
 import com.example.gak.global.security.oauth2.CustomSuccessHandler;
@@ -28,6 +29,7 @@ public class SecurityConfig {
 	private final CustomOAuth2UserService oAuth2UserService;
 	private final CustomOidcUserService oidcUserService;
 	private final CustomSuccessHandler successHandler;
+	private final CustomFailureHandler failureHandler;
 	private final JwtAuthFilter jwtAuthFilter;
 
 	@Bean
@@ -40,7 +42,8 @@ public class SecurityConfig {
 				.userInfoEndpoint(userInfo -> userInfo
 					.userService(oAuth2UserService)
 					.oidcUserService(oidcUserService))
-				.successHandler(successHandler))
+				.successHandler(successHandler)
+				.failureHandler(failureHandler))
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(AccessTokenFreeUrls.PATHS).permitAll()
 				.anyRequest().authenticated())

--- a/src/main/java/com/example/gak/global/security/oauth2/CustomFailureHandler.java
+++ b/src/main/java/com/example/gak/global/security/oauth2/CustomFailureHandler.java
@@ -1,0 +1,75 @@
+package com.example.gak.global.security.oauth2;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import com.example.gak.global.apiPayload.code.GeneralErrorCode;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class CustomFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+	@Override
+	public void onAuthenticationFailure(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException exception
+	) throws IOException {
+		GeneralErrorCode errorCode = resolveErrorCode(exception);
+
+		log.warn("OAuth2 login failure - message: {}",
+			errorCode.getMessage(),
+			exception
+		);
+		
+		String registrationId = extractRegistrationId(request);
+		String redirectUrl = String.format(
+			"http://localhost:3000/api/auth/callback/%s?error=%s",
+			registrationId,
+			errorCode.getCode()
+		);
+		response.sendRedirect(redirectUrl);
+	}
+
+	private GeneralErrorCode resolveErrorCode(AuthenticationException exception) {
+		if (!(exception instanceof OAuth2AuthenticationException e)) {
+			return GeneralErrorCode.OAUTH2_UNKNOWN_ERROR;
+		}
+
+		String code = e.getError().getErrorCode();
+		try {
+			return GeneralErrorCode.valueOf(code);
+		} catch (IllegalArgumentException ignored) {
+		}
+
+		return switch (code) {
+			case "access_denied" -> GeneralErrorCode.OAUTH2_ACCESS_DENIED;
+			case "invalid_request",
+				 "invalid_scope",
+				 "invalid_grant" -> GeneralErrorCode.OAUTH2_INVALID_REQUEST;
+			case "server_error",
+				 "temporarily_unavailable",
+				 "invalid_client",
+				 "unauthorized_client",
+				 "unsupported_response_type" -> GeneralErrorCode.OAUTH2_PROVIDER_ERROR;
+			default -> GeneralErrorCode.OAUTH2_LOGIN_FAILED;
+		};
+	}
+
+	private String extractRegistrationId(HttpServletRequest request) {
+		String uri = request.getRequestURI();
+		String[] parts = uri.split("/");
+		if (parts.length > 0) {
+			return parts[parts.length - 1];
+		}
+		return "unknown";
+	}
+}

--- a/src/main/java/com/example/gak/global/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/gak/global/security/oauth2/CustomOAuth2UserService.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Component;
 
 import com.example.gak.domain.member.service.MemberCommandService;
 import com.example.gak.global.apiPayload.code.GeneralErrorCode;
-import com.example.gak.global.apiPayload.exception.GeneralException;
 import com.example.gak.global.security.oauth2.dto.KakaoMemberDto;
 
 import lombok.RequiredArgsConstructor;
@@ -34,6 +33,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 			return new CustomOAuth2User(registrationId, memberId);
 		}
 
-		throw new GeneralException(GeneralErrorCode.UNSUPPORTED_PROVIDER);
+		throw new OAuth2AuthenticationException(GeneralErrorCode.OAUTH2_UNSUPPORTED_PROVIDER.name());
 	}
 }

--- a/src/main/java/com/example/gak/global/security/oauth2/CustomOidcUserService.java
+++ b/src/main/java/com/example/gak/global/security/oauth2/CustomOidcUserService.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Component;
 
 import com.example.gak.domain.member.service.MemberCommandService;
 import com.example.gak.global.apiPayload.code.GeneralErrorCode;
-import com.example.gak.global.apiPayload.exception.GeneralException;
 import com.example.gak.global.security.oauth2.dto.GoogleMemberDto;
 
 import lombok.RequiredArgsConstructor;
@@ -35,6 +34,6 @@ public class CustomOidcUserService extends OidcUserService {
 			return new CustomOidcUser(registrationId, memberId);
 		}
 
-		throw new GeneralException(GeneralErrorCode.UNSUPPORTED_PROVIDER);
+		throw new OAuth2AuthenticationException(GeneralErrorCode.OAUTH2_UNSUPPORTED_PROVIDER.name());
 	}
 }


### PR DESCRIPTION
## 작업 내용

- OAuth2 실패 핸들러 구현 및 설정 등록
  - 관련 에러 코드 추가
  - 리다이렉트 URL 쿼리 파라미터로 해당 에러의 코드(ex - AUTH401_1) 전달
- 회원 동기화 로직 수정
  - 첫 로그인일 경우 Record 엔티티 생성 및 저장 진행

## 참고 사항

> NONE

## 연관 이슈

> close #48 


<br>