### PR TITLE
refactor: 회원 정보 조회 API 분리 (프로필 표시용 / 수정용)

### DIFF
--- a/src/main/java/com/example/gak/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/gak/domain/member/controller/MemberController.java
@@ -28,13 +28,12 @@ public class MemberController {
 	private final MemberQueryService memberQueryService;
 	private final MemberCommandService memberCommandService;
 
-	@GetMapping("/me")
+	@GetMapping("/me/edit")
 	public ApiResponse<MemberResponseDTO.GetMemberResponseDTO> getMember(
 		@AuthenticationPrincipal CustomOAuth2User oAuth2User
 	) {
 		Long memberId = oAuth2User.getMemberId();
 		MemberResponseDTO.GetMemberResponseDTO response = memberQueryService.getMember(memberId);
-		memberCommandService.markFirstLoginComplete(memberId);
 
 		return ApiResponse.onSuccess(response);
 	}

--- a/src/main/java/com/example/gak/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/gak/domain/member/controller/MemberController.java
@@ -28,6 +28,17 @@ public class MemberController {
 	private final MemberQueryService memberQueryService;
 	private final MemberCommandService memberCommandService;
 
+	@GetMapping("/me/profile")
+	public ApiResponse<MemberResponseDTO.GetProfileResponseDTO> getProfile(
+		@AuthenticationPrincipal CustomOAuth2User oAuth2User
+	) {
+		Long memberId = oAuth2User.getMemberId();
+		MemberResponseDTO.GetProfileResponseDTO response = memberQueryService.getProfile(memberId);
+		memberCommandService.markFirstLoginComplete(memberId);
+
+		return ApiResponse.onSuccess(response);
+	}
+
 	@GetMapping("/me/edit")
 	public ApiResponse<MemberResponseDTO.GetMemberResponseDTO> getMember(
 		@AuthenticationPrincipal CustomOAuth2User oAuth2User

--- a/src/main/java/com/example/gak/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/example/gak/domain/member/converter/MemberConverter.java
@@ -10,11 +10,11 @@ public class MemberConverter {
 			.id(member.getId())
 			.nickname(member.getNickname())
 			.profileImageUrl(member.getProfileImageUrl())
+			.email(member.getEmail())
 			.bio(member.getBio())
 			.firstInterestCategory(member.getFirstInterestCategory())
 			.secondInterestCategory(member.getSecondInterestCategory())
 			.thirdInterestCategory(member.getThirdInterestCategory())
-			.firstLogin(member.isFirstLogin())
 			.build();
 	}
 

--- a/src/main/java/com/example/gak/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/example/gak/domain/member/converter/MemberConverter.java
@@ -2,8 +2,26 @@ package com.example.gak.domain.member.converter;
 
 import com.example.gak.domain.member.dto.MemberResponseDTO;
 import com.example.gak.domain.member.entity.Member;
+import com.example.gak.domain.record.entity.Record;
 
 public class MemberConverter {
+
+	public static MemberResponseDTO.GetProfileResponseDTO toGetProfileResponseDTO(Member member, Record record) {
+		return MemberResponseDTO.GetProfileResponseDTO.builder()
+			.id(member.getId())
+			.nickname(member.getNickname())
+			.profileImageUrl(member.getProfileImageUrl())
+			.email(member.getEmail())
+			.socialProvider(member.getSocialProvider())
+			.totalParticipationTime(record.getTotalParticipationMinutes())
+			.focusedTime(record.getFocusedMinutes())
+			.focusRate(record.getFocusRate())
+			.totalTodoCount(record.getTotalTodoCount())
+			.completedTodoCount(record.getCompletedTodoCount())
+			.todoCompletionRate(record.getTodoCompletionRate())
+			.firstLogin(member.isFirstLogin())
+			.build();
+	}
 
 	public static MemberResponseDTO.GetMemberResponseDTO toGetMemberResponseDTO(Member member) {
 		return MemberResponseDTO.GetMemberResponseDTO.builder()

--- a/src/main/java/com/example/gak/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/gak/domain/member/dto/MemberResponseDTO.java
@@ -9,6 +9,23 @@ public class MemberResponseDTO {
 
 	@Builder
 	@Getter
+	public static class GetProfileResponseDTO {
+		private Long id;
+		private String nickname;
+		private String profileImageUrl;
+		private String email;
+		private String socialProvider;
+		private long totalParticipationTime;
+		private long focusedTime;
+		private int focusRate;
+		private int totalTodoCount;
+		private int completedTodoCount;
+		private int todoCompletionRate;
+		private boolean firstLogin;
+	}
+
+	@Builder
+	@Getter
 	public static class GetMemberResponseDTO {
 		private Long id;
 		private String nickname;

--- a/src/main/java/com/example/gak/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/gak/domain/member/dto/MemberResponseDTO.java
@@ -13,11 +13,11 @@ public class MemberResponseDTO {
 		private Long id;
 		private String nickname;
 		private String profileImageUrl;
+		private String email;
 		private String bio;
 		private SessionCategory firstInterestCategory;
 		private SessionCategory secondInterestCategory;
 		private SessionCategory thirdInterestCategory;
-		private boolean firstLogin;
 	}
 
 	@Builder

--- a/src/main/java/com/example/gak/domain/member/entity/Member.java
+++ b/src/main/java/com/example/gak/domain/member/entity/Member.java
@@ -29,6 +29,8 @@ public class Member extends BaseEntity {
 
 	private String profileImageUrl;
 
+	private String email;
+
 	private String bio;
 
 	@Enumerated(EnumType.STRING)
@@ -52,6 +54,7 @@ public class Member extends BaseEntity {
 	public Member(
 		String nickname,
 		String profileImageUrl,
+		String email,
 		String bio,
 		SessionCategory firstInterestCategory,
 		SessionCategory secondInterestCategory,
@@ -61,6 +64,7 @@ public class Member extends BaseEntity {
 	) {
 		this.nickname = nickname;
 		this.profileImageUrl = profileImageUrl;
+		this.email = email;
 		this.bio = bio;
 		this.firstInterestCategory = firstInterestCategory;
 		this.secondInterestCategory = secondInterestCategory;

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -72,6 +72,9 @@ public class MemberCommandService {
 		Member member = optionalMember.get();
 		if (member.isDeleted()) {
 			member.activate();
+
+			Record record = new Record(member);
+			recordRepository.save(record);
 		}
 
 		return member.getId();

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -53,6 +53,7 @@ public class MemberCommandService {
 			Member member = new Member(
 				oAuth2MemberDto.getNickname(),
 				oAuth2MemberDto.getProfileImage().orElse(""), // 기본 이미지 디자인 완성 시 URL 추가
+				oAuth2MemberDto.getEmail().orElse(null),
 				null,
 				null,
 				null,

--- a/src/main/java/com/example/gak/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberQueryService.java
@@ -7,6 +7,8 @@ import com.example.gak.domain.member.converter.MemberConverter;
 import com.example.gak.domain.member.dto.MemberResponseDTO;
 import com.example.gak.domain.member.entity.Member;
 import com.example.gak.domain.member.repository.MemberRepository;
+import com.example.gak.domain.record.entity.Record;
+import com.example.gak.domain.record.repository.RecordRepository;
 import com.example.gak.global.apiPayload.code.GeneralErrorCode;
 import com.example.gak.global.apiPayload.exception.GeneralException;
 
@@ -18,6 +20,16 @@ import lombok.RequiredArgsConstructor;
 public class MemberQueryService {
 
 	private final MemberRepository memberRepository;
+	private final RecordRepository recordRepository;
+
+	public MemberResponseDTO.GetProfileResponseDTO getProfile(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
+
+		Record record = recordRepository.findByMemberId(memberId);
+
+		return MemberConverter.toGetProfileResponseDTO(member, record);
+	}
 
 	public MemberResponseDTO.GetMemberResponseDTO getMember(Long memberId) {
 		Member member = memberRepository.findById(memberId)

--- a/src/main/java/com/example/gak/domain/record/entity/Record.java
+++ b/src/main/java/com/example/gak/domain/record/entity/Record.java
@@ -106,6 +106,14 @@ public class Record extends BaseEntity {
 		}
 	}
 
+	public int getTotalParticipationMinutes() {
+		return (int)Math.round(totalParticipationTime / 60.0);
+	}
+
+	public int getFocusedMinutes() {
+		return (int)Math.round(focusedTime / 60.0);
+	}
+
 	public int getFocusRate() {
 		if (totalParticipationTime == 0) {
 			return 0;

--- a/src/main/java/com/example/gak/domain/record/entity/Record.java
+++ b/src/main/java/com/example/gak/domain/record/entity/Record.java
@@ -26,7 +26,7 @@ public class Record extends BaseEntity {
 	@Column(name = "record_id")
 	private Long id;
 
-	private long participationTime;
+	private long totalParticipationTime;
 
 	private long focusedTime;
 
@@ -34,7 +34,7 @@ public class Record extends BaseEntity {
 
 	private int totalTodoCount;
 
-	private int achievedTodoCount;
+	private int completedTodoCount;
 
 	private int devSessionCount;
 
@@ -57,11 +57,11 @@ public class Record extends BaseEntity {
 	private Member member;
 
 	public Record(Member member) {
-		this.participationTime = 0;
+		this.totalParticipationTime = 0;
 		this.focusedTime = 0;
 		this.completedSessionCount = 0;
 		this.totalTodoCount = 0;
-		this.achievedTodoCount = 0;
+		this.completedTodoCount = 0;
 		this.devSessionCount = 0;
 		this.designSessionCount = 0;
 		this.planningPmSessionCount = 0;
@@ -74,7 +74,7 @@ public class Record extends BaseEntity {
 	}
 
 	public void increaseParticipationTime(long seconds) {
-		this.participationTime += seconds;
+		this.totalParticipationTime += seconds;
 	}
 
 	public void increaseFocusedTime(long seconds) {
@@ -90,7 +90,7 @@ public class Record extends BaseEntity {
 	}
 
 	public void increaseAchievedTodoCount(int count) {
-		this.achievedTodoCount += count;
+		this.completedTodoCount += count;
 	}
 
 	public void increaseSessionCategoryCount(SessionCategory category) {
@@ -104,5 +104,21 @@ public class Record extends BaseEntity {
 			case TEAM_PROJECT -> teamProjectSessionCount++;
 			case FREE -> etcSessionCount++;
 		}
+	}
+
+	public int getFocusRate() {
+		if (totalParticipationTime == 0) {
+			return 0;
+		}
+
+		return (int)((focusedTime * 100.0) / totalParticipationTime);
+	}
+
+	public int getTodoCompletionRate() {
+		if (totalTodoCount == 0) {
+			return 0;
+		}
+
+		return (int)((completedTodoCount * 100.0) / totalTodoCount);
 	}
 }

--- a/src/main/java/com/example/gak/domain/record/repository/RecordRepository.java
+++ b/src/main/java/com/example/gak/domain/record/repository/RecordRepository.java
@@ -7,4 +7,6 @@ import com.example.gak.domain.record.entity.Record;
 public interface RecordRepository extends JpaRepository<Record, Long> {
 
 	void deleteByMemberId(Long memberId);
+
+	Record findByMemberId(Long memberId);
 }

--- a/src/main/java/com/example/gak/global/security/oauth2/dto/GoogleMemberDto.java
+++ b/src/main/java/com/example/gak/global/security/oauth2/dto/GoogleMemberDto.java
@@ -30,4 +30,9 @@ public class GoogleMemberDto implements OAuth2MemberDto {
 	public Optional<String> getProfileImage() {
 		return Optional.ofNullable(attributes.get("picture")).map(Object::toString);
 	}
+
+	@Override
+	public Optional<String> getEmail() {
+		return Optional.ofNullable(attributes.get("email").toString());
+	}
 }

--- a/src/main/java/com/example/gak/global/security/oauth2/dto/KakaoMemberDto.java
+++ b/src/main/java/com/example/gak/global/security/oauth2/dto/KakaoMemberDto.java
@@ -36,4 +36,9 @@ public class KakaoMemberDto implements OAuth2MemberDto {
 	public Optional<String> getProfileImage() {
 		return Optional.ofNullable(profile.get("profile_image_url"));
 	}
+
+	@Override
+	public Optional<String> getEmail() {
+		return Optional.ofNullable(kakaoAccount.get("email").toString());
+	}
 }

--- a/src/main/java/com/example/gak/global/security/oauth2/dto/OAuth2MemberDto.java
+++ b/src/main/java/com/example/gak/global/security/oauth2/dto/OAuth2MemberDto.java
@@ -11,4 +11,6 @@ public interface OAuth2MemberDto {
 	String getNickname();
 
 	Optional<String> getProfileImage();
+
+	Optional<String> getEmail();
 }


### PR DESCRIPTION
## 작업 내용

- 회원 엔티티에 email 필드 추가 (+ 소셜 회원 DTO에도 추가)
- 회원 조회 API 분리
  - 정보 수정용 조회 API
  - 프로필용 조회 API (집중도, 달성도, 소셜 제공자 정보 추가)
- 기록 엔티티 관련 작업
  - 집중도, 달성도 계산 기능 구현
  - 총 참여 시간, 집중 시간을 분 단위로 조회하는 기능 구현 (저장된 데이터는 초 단위)

## 참고 사항

> 카카오 소셜 로그인 동의 항목에 email 추가는 비즈앱 전환이 필요한데, 비즈앱 전환에는 기본 프로필 이미지가 필요하여 추후에 진행하려 합니다.

## 연관 이슈

> 예) close #51 


<br>