### PR TITLE
feat: 세션 참여 API 구현

### DIFF
--- a/src/main/java/com/example/gak/domain/session/controller/SessionController.java
+++ b/src/main/java/com/example/gak/domain/session/controller/SessionController.java
@@ -96,7 +96,7 @@ public class SessionController {
     @PostMapping("/{sessionId}/join")
     public ApiResponse<SessionResponseDTO.joinSessionResponseDTO> joinSession(
             @AuthenticationPrincipal CustomOAuth2User oAuth2User,
-            @RequestBody SessionRequestDTO.SessionJoinRequestDTO request,
+            @RequestBody @Valid SessionRequestDTO.SessionJoinRequestDTO request,
             @PathVariable Long sessionId
     ){
         return ApiResponse.onSuccess(

--- a/src/main/java/com/example/gak/domain/session/controller/SessionController.java
+++ b/src/main/java/com/example/gak/domain/session/controller/SessionController.java
@@ -10,16 +10,19 @@ import com.example.gak.domain.session.dto.SessionResponseDTO;
 import com.example.gak.domain.session.service.SessionCommandService;
 import com.example.gak.domain.session.service.SessionQueryService;
 import com.example.gak.global.apiPayload.ApiResponse;
+import com.example.gak.global.security.jwt.JwtProvider;
 import com.example.gak.global.security.oauth2.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -90,5 +93,17 @@ public class SessionController {
             @PathVariable Long sessionId
     ){
         return ApiResponse.onSuccess(sessionQueryService.getSessionDetail(sessionId));
+    }
+
+    @Operation(summary = "세션 참여 API")
+    @PostMapping("/{sessionId}/join")
+    public ApiResponse<SessionResponseDTO.joinSessionResponseDTO> joinSession(
+            @AuthenticationPrincipal CustomOAuth2User oAuth2User,
+            @RequestBody SessionRequestDTO.SessionJoinRequestDTO request,
+            @PathVariable Long sessionId
+    ){
+        return ApiResponse.onSuccess(
+                sessionCommandService.joinSession(oAuth2User.getMemberId(), sessionId, request)
+        );
     }
 }

--- a/src/main/java/com/example/gak/domain/session/controller/SessionController.java
+++ b/src/main/java/com/example/gak/domain/session/controller/SessionController.java
@@ -10,19 +10,16 @@ import com.example.gak.domain.session.dto.SessionResponseDTO;
 import com.example.gak.domain.session.service.SessionCommandService;
 import com.example.gak.domain.session.service.SessionQueryService;
 import com.example.gak.global.apiPayload.ApiResponse;
-import com.example.gak.global.security.jwt.JwtProvider;
 import com.example.gak.global.security.oauth2.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 

--- a/src/main/java/com/example/gak/domain/session/converter/SessionConverter.java
+++ b/src/main/java/com/example/gak/domain/session/converter/SessionConverter.java
@@ -1,7 +1,10 @@
 package com.example.gak.domain.session.converter;
 
+import com.example.gak.domain.member.entity.Member;
+import com.example.gak.domain.session.dto.SessionRequestDTO;
 import com.example.gak.domain.session.dto.SessionResponseDTO;
 import com.example.gak.domain.session.entity.SessionRoom;
+import com.example.gak.domain.session.entity.SessionRoomMember;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
@@ -61,6 +64,21 @@ public class SessionConverter {
 
                 .summary(sessionRoom.getSummary())
                 .notice(sessionRoom.getNotice())
+                .build();
+    }
+
+    public static SessionResponseDTO.joinSessionResponseDTO tojoinSessionResponseDTO(
+            SessionRoomMember sessionRoomMember,
+            Member member,
+            SessionRoom sessionRoom,
+            SessionRequestDTO.SessionJoinRequestDTO request
+    ){
+        return SessionResponseDTO.joinSessionResponseDTO.builder()
+                .memberId(member.getId())
+                .sessionId(sessionRoom.getId())
+                .role(sessionRoomMember.getRole())
+                .gole(request.getGoal())
+                .todos(request.getTodos())
                 .build();
     }
 }

--- a/src/main/java/com/example/gak/domain/session/converter/SessionConverter.java
+++ b/src/main/java/com/example/gak/domain/session/converter/SessionConverter.java
@@ -77,7 +77,7 @@ public class SessionConverter {
                 .memberId(member.getId())
                 .sessionId(sessionRoom.getId())
                 .role(sessionRoomMember.getRole())
-                .gole(request.getGoal())
+                .goal(request.getGoal())
                 .todos(request.getTodos())
                 .build();
     }

--- a/src/main/java/com/example/gak/domain/session/converter/SessionConverter.java
+++ b/src/main/java/com/example/gak/domain/session/converter/SessionConverter.java
@@ -18,7 +18,7 @@ public class SessionConverter {
                 .title(sessionRoom.getTitle())
                 .hostNickname(sessionRoom.getMember().getNickname())
                 .imageUrl(sessionRoom.getThumbnailImageUrl())
-                .currentParticipants(0) // TODO: 실시간 통신 구현 이후 실제 카운트로 수정
+                .currentParticipants(sessionRoom.getCurrentCount())
                 .maxParticipants(sessionRoom.getMaxCapacity())
                 .startTime(sessionRoom.getStartTime())
                 .sessionDurationMinutes(sessionRoom.getDurationMinutes())
@@ -56,7 +56,7 @@ public class SessionConverter {
                 .title(sessionRoom.getTitle())
                 .hostNickname(sessionRoom.getMember().getNickname())
                 .imageUrl(sessionRoom.getThumbnailImageUrl())
-                .currentParticipants(0) // TODO: 실시간 통신 구현 이후 실제 카운트로 수정
+                .currentParticipants(sessionRoom.getCurrentCount())
                 .maxParticipants(sessionRoom.getMaxCapacity())
                 .sessionDurationMinutes(sessionRoom.getDurationMinutes())
                 .startTime(sessionRoom.getStartTime())

--- a/src/main/java/com/example/gak/domain/session/dto/SessionRequestDTO.java
+++ b/src/main/java/com/example/gak/domain/session/dto/SessionRequestDTO.java
@@ -2,7 +2,6 @@ package com.example.gak.domain.session.dto;
 
 import com.example.gak.domain.common.entity.enums.SessionCategory;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/example/gak/domain/session/dto/SessionRequestDTO.java
+++ b/src/main/java/com/example/gak/domain/session/dto/SessionRequestDTO.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 
 import jakarta.validation.constraints.*;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class SessionRequestDTO {
 
@@ -50,5 +51,12 @@ public class SessionRequestDTO {
 
         @Min(0)
         private Integer requiredAchievementRate = 0;
+    }
+
+    @Getter
+    @Builder
+    public static class SessionJoinRequestDTO{
+        private String goal;
+        private List<String> todos;
     }
 }

--- a/src/main/java/com/example/gak/domain/session/dto/SessionRequestDTO.java
+++ b/src/main/java/com/example/gak/domain/session/dto/SessionRequestDTO.java
@@ -55,7 +55,12 @@ public class SessionRequestDTO {
     @Getter
     @Builder
     public static class SessionJoinRequestDTO{
+
+        @NotNull
+        @Size(max = 50)
         private String goal;
-        private List<String> todos;
+
+        @NotNull
+        private List<@Size(max = 50) String> todos;
     }
 }

--- a/src/main/java/com/example/gak/domain/session/dto/SessionResponseDTO.java
+++ b/src/main/java/com/example/gak/domain/session/dto/SessionResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.gak.domain.session.dto;
 
+import com.example.gak.domain.session.entity.enums.SessionParticipantRole;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -54,5 +55,15 @@ public class SessionResponseDTO {
         private String imageUrl;
         private String summary;
         private String notice;
+    }
+
+    @Builder
+    @Getter
+    public static class joinSessionResponseDTO{
+        private Long sessionId;
+        private Long memberId;
+        private String gole;
+        private List<String> todos;
+        private SessionParticipantRole role;
     }
 }

--- a/src/main/java/com/example/gak/domain/session/dto/SessionResponseDTO.java
+++ b/src/main/java/com/example/gak/domain/session/dto/SessionResponseDTO.java
@@ -62,7 +62,7 @@ public class SessionResponseDTO {
     public static class joinSessionResponseDTO{
         private Long sessionId;
         private Long memberId;
-        private String gole;
+        private String goal;
         private List<String> todos;
         private SessionParticipantRole role;
     }

--- a/src/main/java/com/example/gak/domain/session/entity/SessionRoom.java
+++ b/src/main/java/com/example/gak/domain/session/entity/SessionRoom.java
@@ -55,6 +55,9 @@ public class SessionRoom extends BaseEntity {
 	@Column(nullable = false)
 	private Integer maxCapacity;
 
+	@Column(nullable = false)
+	private Integer currentCount = 0;
+
 	@Enumerated(EnumType.STRING)
 	private SessionRoomStatus status;
 

--- a/src/main/java/com/example/gak/domain/session/entity/SessionRoomMember.java
+++ b/src/main/java/com/example/gak/domain/session/entity/SessionRoomMember.java
@@ -4,16 +4,7 @@ import com.example.gak.domain.common.entity.BaseEntity;
 import com.example.gak.domain.member.entity.Member;
 import com.example.gak.domain.session.entity.enums.SessionParticipantRole;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +12,15 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+		name = "session_room_member",
+		uniqueConstraints = {
+				@UniqueConstraint(
+						name = "uk_session_room_member_member_session",
+						columnNames = {"member_id", "session_room_id"}
+				)
+		}
+)
 public class SessionRoomMember extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/example/gak/domain/session/repository/SessionRoomMemberRepository.java
+++ b/src/main/java/com/example/gak/domain/session/repository/SessionRoomMemberRepository.java
@@ -2,22 +2,10 @@ package com.example.gak.domain.session.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.example.gak.domain.session.entity.SessionRoomMember;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface SessionRoomMemberRepository extends JpaRepository<SessionRoomMember, Long> {
 
     void deleteByMemberId(Long memberId);
 
-    int countBySessionRoomId(Long sessionRoomId);
-
     boolean existsBySessionRoomIdAndMemberId(Long sessionId, Long memberId);
-
-    @Query("""
-                select count(srm) > 0
-                from SessionRoomMember srm
-                where srm.sessionRoom.id = :sessionId
-                  and srm.role = 'HOST'
-            """)
-    boolean existsSessionHost(@Param("sessionId") Long sessionId);
 }

--- a/src/main/java/com/example/gak/domain/session/repository/SessionRoomMemberRepository.java
+++ b/src/main/java/com/example/gak/domain/session/repository/SessionRoomMemberRepository.java
@@ -1,10 +1,23 @@
 package com.example.gak.domain.session.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.example.gak.domain.session.entity.SessionRoomMember;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SessionRoomMemberRepository extends JpaRepository<SessionRoomMember, Long> {
 
-	void deleteByMemberId(Long memberId);
+    void deleteByMemberId(Long memberId);
+
+    int countBySessionRoomId(Long sessionRoomId);
+
+    boolean existsBySessionRoomIdAndMemberId(Long sessionId, Long memberId);
+
+    @Query("""
+                select count(srm) > 0
+                from SessionRoomMember srm
+                where srm.sessionRoom.id = :sessionId
+                  and srm.role = 'HOST'
+            """)
+    boolean existsSessionHost(@Param("sessionId") Long sessionId);
 }

--- a/src/main/java/com/example/gak/domain/session/repository/SessionRoomRepository.java
+++ b/src/main/java/com/example/gak/domain/session/repository/SessionRoomRepository.java
@@ -1,21 +1,30 @@
 package com.example.gak.domain.session.repository;
 
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.*;
 
 import com.example.gak.domain.session.entity.SessionRoom;
 import com.example.gak.domain.session.entity.enums.SessionRoomStatus;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface SessionRoomRepository extends JpaRepository<SessionRoom, Long>,
-	JpaSpecificationExecutor<SessionRoom> {
+        JpaSpecificationExecutor<SessionRoom> {
 
-	void deleteByMemberId(Long memberId);
+    void deleteByMemberId(Long memberId);
 
-	boolean existsByMemberIdAndStatusNot(Long memberId, SessionRoomStatus status);
+    boolean existsByMemberIdAndStatusNot(Long memberId, SessionRoomStatus status);
 
-	@EntityGraph(attributePaths = {"member"})
-	Optional<SessionRoom> findWithMemberById(Long id);
+    @EntityGraph(attributePaths = {"member"})
+    Optional<SessionRoom> findWithMemberById(Long id);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+    UPDATE SessionRoom s
+    SET s.currentCount = s.currentCount + 1
+    WHERE s.id = :sessionId
+      AND s.currentCount < s.maxCapacity
+      AND s.status <> com.example.gak.domain.session.entity.enums.SessionRoomStatus.COMPLETED
+""")
+    int increaseCountIfAvailable(@Param("sessionId") Long sessionId);
 }

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -140,12 +140,7 @@ public class SessionCommandService {
         try {
             return sessionRoomMemberRepository.save(newMember);
         } catch (DataIntegrityViolationException e) {
-            String msg = e.getMostSpecificCause().getMessage();
-            if (msg != null && msg.contains("uk_session_room_member_member_session")) {
-                throw new GeneralException(GeneralErrorCode.SESSION_ALREADY_JOINED);
-            }else {
-                throw e;
-            }
+            throw new GeneralException(GeneralErrorCode.SESSION_ALREADY_JOINED);
         }
     }
 }

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -117,8 +117,9 @@ public class SessionCommandService {
     private void increaseCountOrThrow(SessionRoom targetSessionRoom) {
         int updated = sessionRoomRepository.increaseCountIfAvailable(targetSessionRoom.getId());
         if (updated == 0) {
-            SessionRoomStatus status = targetSessionRoom.getStatus();
-            if (status == SessionRoomStatus.COMPLETED) {
+            SessionRoom currentSessionRoom = sessionRoomRepository.findById(targetSessionRoom.getId())
+                    .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_SESSION));
+            if (currentSessionRoom.getStatus() == SessionRoomStatus.COMPLETED) {
                 throw new GeneralException(GeneralErrorCode.SESSION_ALREADY_COMPLETED);
             } else {
                 throw new GeneralException(GeneralErrorCode.SESSION_CAPACITY_EXCEEDED);

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -3,19 +3,30 @@ package com.example.gak.domain.session.service;
 import com.example.gak.domain.member.entity.Member;
 import com.example.gak.domain.member.repository.MemberRepository;
 import com.example.gak.domain.session.dto.SessionRequestDTO;
+import com.example.gak.domain.session.dto.SessionResponseDTO;
 import com.example.gak.domain.session.entity.SessionRoom;
+import com.example.gak.domain.session.entity.SessionRoomMember;
+import com.example.gak.domain.session.entity.enums.SessionParticipantRole;
 import com.example.gak.domain.session.entity.enums.SessionRoomStatus;
+import com.example.gak.domain.session.repository.SessionRoomMemberRepository;
 import com.example.gak.domain.session.repository.SessionRoomRepository;
+import com.example.gak.domain.subtask.entity.SubTask;
+import com.example.gak.domain.subtask.repository.SubTaskRepository;
+import com.example.gak.domain.task.entity.Task;
+import com.example.gak.domain.task.repository.TaskRepository;
 import com.example.gak.global.apiPayload.code.GeneralErrorCode;
 import com.example.gak.global.apiPayload.exception.GeneralException;
 import com.example.gak.global.aws.AmazonS3Manager;
 import com.example.gak.global.validator.ImageFileValidator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+
+import static com.example.gak.domain.session.converter.SessionConverter.tojoinSessionResponseDTO;
 
 @Service
 @Transactional
@@ -26,6 +37,10 @@ public class SessionCommandService {
 
     private final MemberRepository memberRepository;
     private final SessionRoomRepository sessionRoomRepository;
+    private final SessionRoomMemberRepository sessionRoomMemberRepository;
+    private final SubTaskRepository subTaskRepository;
+    private final TaskRepository taskRepository;
+
     private final AmazonS3Manager amazonS3Manager;
     private final ImageFileValidator imageFileValidator;
 
@@ -68,5 +83,68 @@ public class SessionCommandService {
         );
         sessionRoomRepository.save(newSessionRoom);
         return newSessionRoom;
+    }
+
+    public SessionResponseDTO.joinSessionResponseDTO joinSession(
+            Long memberId,
+            Long sessionId,
+            SessionRequestDTO.SessionJoinRequestDTO request
+    ) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
+
+        SessionRoom targetSessionRoom = sessionRoomRepository.findWithMemberById(sessionId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_SESSION));
+
+        increaseCountOrThrow(targetSessionRoom);
+        SessionParticipantRole role = determineRole(member, targetSessionRoom);
+        SessionRoomMember sessionRoomMember = saveSessionRoomMember(targetSessionRoom, member, role);
+        saveGoalTask(targetSessionRoom, member, request);
+
+        return tojoinSessionResponseDTO(sessionRoomMember, member, targetSessionRoom, request);
+    }
+
+    private void saveGoalTask(SessionRoom sessionRoom, Member member, SessionRequestDTO.SessionJoinRequestDTO request) {
+        Task newTask = new Task(request.getGoal(), sessionRoom, member);
+        taskRepository.save(newTask);
+
+        request.getTodos().forEach(todo -> {
+            SubTask subTask = new SubTask(todo, newTask);
+            subTaskRepository.save(subTask);
+        });
+    }
+
+    private void increaseCountOrThrow(SessionRoom targetSessionRoom) {
+        int updated = sessionRoomRepository.increaseCountIfAvailable(targetSessionRoom.getId());
+        if (updated == 0) {
+            SessionRoomStatus status = targetSessionRoom.getStatus();
+            if (status == SessionRoomStatus.COMPLETED) {
+                throw new GeneralException(GeneralErrorCode.SESSION_ALREADY_COMPLETED);
+            } else {
+                throw new GeneralException(GeneralErrorCode.SESSION_CAPACITY_EXCEEDED);
+            }
+        }
+    }
+
+    private SessionParticipantRole determineRole(Member member, SessionRoom sessionRoom) {
+        if (member.getId().equals(sessionRoom.getMember().getId()) &&
+                sessionRoom.getStatus() == SessionRoomStatus.WAITING) {
+            return SessionParticipantRole.HOST;
+        }
+        return SessionParticipantRole.PARTICIPANT;
+    }
+
+    private SessionRoomMember saveSessionRoomMember(SessionRoom sessionRoom, Member member, SessionParticipantRole role) {
+        SessionRoomMember newMember = new SessionRoomMember(role, sessionRoom, member);
+        try {
+            return sessionRoomMemberRepository.save(newMember);
+        } catch (DataIntegrityViolationException e) {
+            String msg = e.getMostSpecificCause().getMessage();
+            if (msg != null && msg.contains("uk_session_room_member_member_session")) {
+                throw new GeneralException(GeneralErrorCode.SESSION_ALREADY_JOINED);
+            }else {
+                throw e;
+            }
+        }
     }
 }

--- a/src/main/java/com/example/gak/domain/subtask/repository/SubTaskRepository.java
+++ b/src/main/java/com/example/gak/domain/subtask/repository/SubTaskRepository.java
@@ -16,4 +16,6 @@ public interface SubTaskRepository extends JpaRepository<SubTask, Long> {
 		DELETE FROM SubTask s WHERE s.task.id IN :taskIds
 		""")
 	void deleteByTaskIdIn(@Param("taskIds") List<Long> taskIds);
+
+	List<SubTask> findByTaskId(Long taskId);
 }

--- a/src/main/java/com/example/gak/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/example/gak/domain/task/repository/TaskRepository.java
@@ -9,4 +9,6 @@ import com.example.gak.domain.task.entity.Task;
 public interface TaskRepository extends JpaRepository<Task, Long> {
 
 	List<Task> findByMemberId(Long memberId);
+
+	List<Task> findBySessionRoomIdAndMemberId(Long sessionRoomId, Long memberId);
 }

--- a/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/gak/global/apiPayload/code/GeneralErrorCode.java
@@ -36,6 +36,9 @@ public enum GeneralErrorCode implements BaseErrorCode {
 	// 세션 관련
 	SESSION_START_TIME_TOO_SOON(HttpStatus.BAD_REQUEST, "SESSION400_1", "세션 시작 시간은 현재 시각 기준 5분 이후로 설정해야 합니다."),
 	NOT_FOUND_SESSION(HttpStatus.NOT_FOUND, "SESSION404_1", "존재하지 않는 세션입니다."),
+	SESSION_CAPACITY_EXCEEDED(HttpStatus.BAD_REQUEST, "SESSION400_2", "세션 정원이 초과되었습니다."),
+	SESSION_ALREADY_JOINED(HttpStatus.BAD_REQUEST, "SESSION400_3", "이미 참여한 세션입니다."),
+	SESSION_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "SESSION400_4", "이미 종료된 세션입니다."),
 
 	// 파일 관련
 	INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "FILE400_1", "허용되지 않은 이미지 형식입니다."),


### PR DESCRIPTION
## 작업 내용

> 세션 참여 API를 구현하였습니다.

## 참고 사항
>세션 참여 기능 구현 중 Race Condition으로 인한 동시성 문제가 발생해 DB 스키마 관련 변경사항이 있습니다.
>
>**1. 실제 입장 인원이 최대 수용 정원을 초과해버리는 문제**
>- 여러 사용자가 동시에 세션 참여를 요청할 경우, 기존 로직에서는 참여 인원을 확인하고 업데이트하는 사이에 다른 트랜잭션이 끼어들어 실제 참여 인원이 세션 최대 정원을 초과할 수 있습니다.
>- 서버가 분산 환경이고, 세션 정보가 조회가 잦은 동시에 최대 정원 초과를 반드시 방지해야 했기 때문에 **SessionRoom 엔티티에 currentCount 필드를 추가**하고, 조건부 Update 쿼리(UPDATE ... WHERE currentCount < maxCapacity)를 사용하여 참여 인원 증가를 원자적으로 처리하도록 하였습니다.
>
> **2. 동일 사용자가 같은 세션에 중복으로 참여할 수 있는 문제**
> - 사용자가 동시에 여러 요청을 보내거나 동시성 상황에서 동일 사용자가 중복으로 세션에 참여할 수 있습니다.
> - 위 상황 방지를 위해 **SessionRoomMember 엔티티에 member_id + session_room_id 유니크 제약 조건을 추가**하였습니다.
> - DB에서 유니크 제약으로 중복 레코드 생성을 방지하며, 애플리케이션에서는 DataIntegrityViolationException을 처리하여 동일 사용자가 중복 참여 시 SESSION_ALREADY_JOINED 예외를 반환하도록 설계하였습니다.

## 연관 이슈

> close #49


<br>