### PR TITLE
fix: 세션 상세 조회 API URL 패턴을 숫자 ID만 허용하도록 수정

### DIFF
--- a/src/main/java/com/example/gak/global/security/AccessTokenFreeUrls.java
+++ b/src/main/java/com/example/gak/global/security/AccessTokenFreeUrls.java
@@ -6,12 +6,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class AccessTokenFreeUrls {
 
-    public static final String[] PATHS = {
-            "/api/v1/auth/refresh",
-            "/health",
-            "/swagger-ui/**",
-            "/v3/api-docs/**",
-            "/api/v1/sessions",
-            "/api/v1/sessions/{sessionId}",
-    };
+	public static final String[] PATHS = {
+		"/api/v1/auth/refresh",
+		"/health",
+		"/swagger-ui/**",
+		"/v3/api-docs/**",
+		"/api/v1/sessions",
+		"/api/v1/sessions/{sessionId:\\d+}"
+	};
 }


### PR DESCRIPTION
## 작업 내용

> 세션 상세 조회 API URL 패턴을 숫자 ID만 허용하도록 수정했습니다.

## 참고 사항

> 

## 연관 이슈

> close #65 


<br>