### PR TITLE
feat: 회원 마이페이지 정보 관련 API 작업

### DIFF
--- a/src/main/java/com/example/gak/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/gak/domain/member/controller/MemberController.java
@@ -61,7 +61,7 @@ public class MemberController {
 	@PatchMapping("/me")
 	public ApiResponse<MemberResponseDTO.UpdateMemberResponseDTO> updateMember(
 		@AuthenticationPrincipal CustomOAuth2User oAuth2User,
-		@RequestBody MemberRequestDTO.UpdateMemberRequestDTO request
+		@Valid @RequestBody MemberRequestDTO.UpdateMemberRequestDTO request
 	) {
 		MemberResponseDTO.UpdateMemberResponseDTO response = memberCommandService.updateMember(
 			oAuth2User.getMemberId(),

--- a/src/main/java/com/example/gak/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/gak/domain/member/controller/MemberController.java
@@ -18,6 +18,7 @@ import com.example.gak.domain.member.service.MemberQueryService;
 import com.example.gak.global.apiPayload.ApiResponse;
 import com.example.gak.global.security.oauth2.CustomOAuth2User;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -95,6 +96,7 @@ public class MemberController {
 		);
 	}
 
+	@Hidden
 	@Operation(summary = "내 이메일 수정 API")
 	@PatchMapping("/me/email")
 	public ApiResponse<MemberResponseDTO.UpdateMemberResponseDTO> updateEmail(

--- a/src/main/java/com/example/gak/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/gak/domain/member/controller/MemberController.java
@@ -45,13 +45,27 @@ public class MemberController {
 		return ApiResponse.onSuccess(response);
 	}
 
-	@Operation(summary = "내 정보 조회 API (수정용)")
+	@Operation(summary = "내 정보 조회 API (마이페이지)")
 	@GetMapping("/me/edit")
 	public ApiResponse<MemberResponseDTO.GetMemberResponseDTO> getMember(
 		@AuthenticationPrincipal CustomOAuth2User oAuth2User
 	) {
 		Long memberId = oAuth2User.getMemberId();
 		MemberResponseDTO.GetMemberResponseDTO response = memberQueryService.getMember(memberId);
+
+		return ApiResponse.onSuccess(response);
+	}
+
+	@Operation(summary = "내 정보 수정 API (마이페이지)")
+	@PatchMapping("/me")
+	public ApiResponse<MemberResponseDTO.UpdateMemberResponseDTO> updateMember(
+		@AuthenticationPrincipal CustomOAuth2User oAuth2User,
+		@RequestBody MemberRequestDTO.UpdateMemberRequestDTO request
+	) {
+		MemberResponseDTO.UpdateMemberResponseDTO response = memberCommandService.updateMember(
+			oAuth2User.getMemberId(),
+			request
+		);
 
 		return ApiResponse.onSuccess(response);
 	}

--- a/src/main/java/com/example/gak/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/example/gak/domain/member/converter/MemberConverter.java
@@ -12,13 +12,15 @@ public class MemberConverter {
 			.nickname(member.getNickname())
 			.profileImageUrl(member.getProfileImageUrl())
 			.email(member.getEmail())
+			.bio(member.getBio())
 			.socialProvider(member.getSocialProvider())
-			.totalParticipationTime(record.getTotalParticipationMinutes())
-			.focusedTime(record.getFocusedMinutes())
+			.totalParticipationTime(record.getTotalParticipationTime())
+			.focusedTime(record.getFocusedTime())
 			.focusRate(record.getFocusRate())
 			.totalTodoCount(record.getTotalTodoCount())
 			.completedTodoCount(record.getCompletedTodoCount())
 			.todoCompletionRate(record.getTodoCompletionRate())
+			.participationSessionCount(record.getParticipationSessionCount())
 			.firstLogin(member.isFirstLogin())
 			.build();
 	}

--- a/src/main/java/com/example/gak/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/example/gak/domain/member/dto/MemberRequestDTO.java
@@ -14,6 +14,39 @@ import lombok.NoArgsConstructor;
 
 public class MemberRequestDTO {
 
+	@Schema(name = "회원 마이페이지 정보 수정 요청")
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class UpdateMemberRequestDTO {
+
+		@Pattern(
+			regexp = "^[a-zA-Z0-9가-힣]+$",
+			message = "닉네임은 한글, 영어, 숫자만 가능합니다."
+		)
+		@NotBlank
+		@Size(min = 2, max = 10)
+		private String nickname;
+
+		@Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+		@Email
+		private String email;
+
+		@Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+		@Size(max = 100)
+		private String bio;
+
+		@Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+		private SessionCategory firstInterestCategory;
+
+		@Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+		private SessionCategory secondInterestCategory;
+
+		@Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+		private SessionCategory thirdInterestCategory;
+	}
+
 	@Schema(name = "회원 닉네임 수정 요청")
 	@AllArgsConstructor
 	@NoArgsConstructor

--- a/src/main/java/com/example/gak/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/gak/domain/member/dto/MemberResponseDTO.java
@@ -25,6 +25,9 @@ public class MemberResponseDTO {
 		@Schema(nullable = true)
 		private String email;
 
+		@Schema(nullable = true)
+		private String bio;
+
 		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
 		private String socialProvider;
 
@@ -45,6 +48,9 @@ public class MemberResponseDTO {
 
 		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
 		private int todoCompletionRate;
+
+		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+		private int participationSessionCount;
 
 		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
 		private boolean firstLogin;

--- a/src/main/java/com/example/gak/domain/member/entity/Member.java
+++ b/src/main/java/com/example/gak/domain/member/entity/Member.java
@@ -95,6 +95,10 @@ public class Member extends BaseEntity {
 		this.email = email;
 	}
 
+	public void updateBio(String bio) {
+		this.bio = bio;
+	}
+
 	public void updateInterestCategories(
 		SessionCategory firstInterestCategory,
 		SessionCategory secondInterestCategory,

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -102,6 +102,7 @@ public class MemberCommandService {
 			request.getThirdInterestCategory()
 		);
 
+		// 이메일 수정 가능 여부가 결정되면 코드 수정
 		String newEmail = request.getEmail();
 		if (newEmail != null) {
 			member.updateEmail(newEmail);

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -95,13 +95,17 @@ public class MemberCommandService {
 		Member member = getMember(memberId);
 
 		member.updateNickname(request.getNickname());
-		member.updateEmail(request.getEmail());
 		member.updateBio(request.getBio());
 		member.updateInterestCategories(
 			request.getFirstInterestCategory(),
 			request.getSecondInterestCategory(),
 			request.getThirdInterestCategory()
 		);
+
+		String newEmail = request.getEmail();
+		if (newEmail != null) {
+			member.updateEmail(newEmail);
+		}
 
 		return MemberConverter.toUpdateMemberResponseDTO(member);
 	}

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -88,6 +88,24 @@ public class MemberCommandService {
 		}
 	}
 
+	public MemberResponseDTO.UpdateMemberResponseDTO updateMember(
+		Long memberId,
+		MemberRequestDTO.UpdateMemberRequestDTO request
+	) {
+		Member member = getMember(memberId);
+
+		member.updateNickname(request.getNickname());
+		member.updateEmail(request.getEmail());
+		member.updateBio(request.getBio());
+		member.updateInterestCategories(
+			request.getFirstInterestCategory(),
+			request.getSecondInterestCategory(),
+			request.getThirdInterestCategory()
+		);
+
+		return MemberConverter.toUpdateMemberResponseDTO(member);
+	}
+
 	public MemberResponseDTO.UpdateMemberResponseDTO updateProfileImage(Long memberId, MultipartFile newProfileImage) {
 		Member member = getMember(memberId);
 

--- a/src/main/java/com/example/gak/domain/record/entity/Record.java
+++ b/src/main/java/com/example/gak/domain/record/entity/Record.java
@@ -30,7 +30,7 @@ public class Record extends BaseEntity {
 
 	private long focusedTime;
 
-	private int completedSessionCount;
+	private int participationSessionCount;
 
 	private int totalTodoCount;
 
@@ -59,7 +59,7 @@ public class Record extends BaseEntity {
 	public Record(Member member) {
 		this.totalParticipationTime = 0;
 		this.focusedTime = 0;
-		this.completedSessionCount = 0;
+		this.participationSessionCount = 0;
 		this.totalTodoCount = 0;
 		this.completedTodoCount = 0;
 		this.devSessionCount = 0;
@@ -81,15 +81,11 @@ public class Record extends BaseEntity {
 		this.focusedTime += seconds;
 	}
 
-	public void increaseCompletedSessionCount() {
-		this.completedSessionCount++;
-	}
-
 	public void increaseTotalTodoCount(int count) {
 		this.totalTodoCount += count;
 	}
 
-	public void increaseAchievedTodoCount(int count) {
+	public void increaseCompletedTodoCount(int count) {
 		this.completedTodoCount += count;
 	}
 
@@ -104,6 +100,7 @@ public class Record extends BaseEntity {
 			case TEAM_PROJECT -> teamProjectSessionCount++;
 			case FREE -> etcSessionCount++;
 		}
+		participationSessionCount++;
 	}
 
 	public int getTotalParticipationMinutes() {


### PR DESCRIPTION
## 작업 내용

- 회원 프로필 정보 조회 API와 마이페이지 상단 정보 조회 API 통합
  - 기본 프로필 조회 응답 DTO에 자기소개, 참여 세션 수 정보 추가
- 마이페이지 회원 정보 수정 API 구현

## 참고 사항

> NONE

## 연관 이슈

> close #81