### PR TITLE
feat: 회원 리포트 통계 데이터 조회 API 구현

### DIFF
--- a/src/main/java/com/example/gak/domain/common/entity/enums/EmojiType.java
+++ b/src/main/java/com/example/gak/domain/common/entity/enums/EmojiType.java
@@ -1,0 +1,9 @@
+package com.example.gak.domain.common.entity.enums;
+
+public enum EmojiType {
+
+	HEART,
+	THUMBS_UP,
+	THUMBS_DOWN,
+	STAR
+}

--- a/src/main/java/com/example/gak/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/gak/domain/member/controller/MemberController.java
@@ -57,6 +57,16 @@ public class MemberController {
 		return ApiResponse.onSuccess(response);
 	}
 
+	@Operation(summary = "내 리포트 통계 정보 조회 API (마이페이지)")
+	@GetMapping("/me/report-stats")
+	public ApiResponse<MemberResponseDTO.GetReportStats> getReportStats(
+		@AuthenticationPrincipal CustomOAuth2User oAuth2User
+	) {
+		return ApiResponse.onSuccess(
+			memberQueryService.getReportStats(oAuth2User.getMemberId())
+		);
+	}
+
 	@Operation(summary = "내 정보 수정 API (마이페이지)")
 	@PatchMapping("/me")
 	public ApiResponse<MemberResponseDTO.UpdateMemberResponseDTO> updateMember(

--- a/src/main/java/com/example/gak/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/gak/domain/member/dto/MemberResponseDTO.java
@@ -1,5 +1,8 @@
 package com.example.gak.domain.member.dto;
 
+import java.util.List;
+
+import com.example.gak.domain.common.entity.enums.EmojiType;
 import com.example.gak.domain.common.entity.enums.SessionCategory;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -114,5 +117,56 @@ public class MemberResponseDTO {
 
 		@Schema(nullable = true)
 		private SessionCategory thirdInterestCategory;
+	}
+
+	@Schema(name = "회원 리포트 통계 정보 응답")
+	@Builder
+	@Getter
+	public static class GetReportStats {
+
+		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+		private long focusedTime;
+
+		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+		private long totalParticipationTime;
+
+		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+		private int todoCompletionRate;
+
+		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+		private int focusRate;
+
+		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+		private List<SessionParticipationStat> sessionParticipationStats;
+
+		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+		private List<ReceivedEmojiStat> receivedEmojis;
+	}
+
+	@Schema(name = "세션 참여 현황 응답")
+	@Builder
+	@Getter
+	public static class SessionParticipationStat {
+
+		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+		private SessionCategory categoryName;
+
+		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+		private int count;
+
+		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+		private int rate;
+	}
+
+	@Schema(name = "받은 이모지 현황 응답")
+	@Builder
+	@Getter
+	public static class ReceivedEmojiStat {
+
+		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+		private EmojiType emojiName;
+
+		@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+		private int count;
 	}
 }

--- a/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberCommandService.java
@@ -81,7 +81,7 @@ public class MemberCommandService {
 	}
 
 	public void markFirstLoginComplete(Long memberId) {
-		Member member = getMember(memberId);
+		Member member = findMember(memberId);
 
 		if (member.isFirstLogin()) {
 			member.markLoginDone();
@@ -92,7 +92,7 @@ public class MemberCommandService {
 		Long memberId,
 		MemberRequestDTO.UpdateMemberRequestDTO request
 	) {
-		Member member = getMember(memberId);
+		Member member = findMember(memberId);
 
 		member.updateNickname(request.getNickname());
 		member.updateBio(request.getBio());
@@ -112,7 +112,7 @@ public class MemberCommandService {
 	}
 
 	public MemberResponseDTO.UpdateMemberResponseDTO updateProfileImage(Long memberId, MultipartFile newProfileImage) {
-		Member member = getMember(memberId);
+		Member member = findMember(memberId);
 
 		if (newProfileImage != null) {
 			String newProfileImageUrl = amazonS3Manager.uploadFile(
@@ -134,7 +134,7 @@ public class MemberCommandService {
 		Long memberId,
 		MemberRequestDTO.UpdateMemberNicknameRequestDTO request
 	) {
-		Member member = getMember(memberId);
+		Member member = findMember(memberId);
 		member.updateNickname(request.getNickname());
 
 		return MemberConverter.toUpdateMemberResponseDTO(member);
@@ -144,7 +144,7 @@ public class MemberCommandService {
 		Long memberId,
 		MemberRequestDTO.UpdateMemberEmailRequestDTO request
 	) {
-		Member member = getMember(memberId);
+		Member member = findMember(memberId);
 
 		if (request != null) {
 			member.updateEmail(request.getEmail());
@@ -157,7 +157,7 @@ public class MemberCommandService {
 		Long memberId,
 		MemberRequestDTO.UpdateMemberInterestCategoriesRequestDTO request
 	) {
-		Member member = getMember(memberId);
+		Member member = findMember(memberId);
 
 		if (request != null) {
 			member.updateInterestCategories(
@@ -171,7 +171,7 @@ public class MemberCommandService {
 	}
 
 	public void deleteProfileImage(Long memberId) {
-		Member member = getMember(memberId);
+		Member member = findMember(memberId);
 
 		String profileImageUrl = member.getProfileImageUrl();
 		if (profileImageUrl == null || profileImageUrl.isEmpty()) {
@@ -187,7 +187,7 @@ public class MemberCommandService {
 			throw new GeneralException(GeneralErrorCode.MEMBER_HAS_ACTIVE_SESSION);
 		}
 
-		Member member = getMember(memberId);
+		Member member = findMember(memberId);
 
 		recordRepository.deleteByMemberId(memberId);
 		chatMessageRepository.deleteByMemberId(memberId);
@@ -207,7 +207,7 @@ public class MemberCommandService {
 		member.delete();
 	}
 
-	private Member getMember(Long memberId) {
+	private Member findMember(Long memberId) {
 		return memberRepository.findById(memberId)
 			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
 	}

--- a/src/main/java/com/example/gak/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/example/gak/domain/member/service/MemberQueryService.java
@@ -1,8 +1,14 @@
 package com.example.gak.domain.member.service;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.gak.domain.common.entity.enums.EmojiType;
+import com.example.gak.domain.common.entity.enums.SessionCategory;
 import com.example.gak.domain.member.converter.MemberConverter;
 import com.example.gak.domain.member.dto.MemberResponseDTO;
 import com.example.gak.domain.member.entity.Member;
@@ -23,18 +29,65 @@ public class MemberQueryService {
 	private final RecordRepository recordRepository;
 
 	public MemberResponseDTO.GetProfileResponseDTO getProfile(Long memberId) {
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
-
+		Member member = findMember(memberId);
 		Record record = recordRepository.findByMemberId(memberId);
 
 		return MemberConverter.toGetProfileResponseDTO(member, record);
 	}
 
 	public MemberResponseDTO.GetMemberResponseDTO getMember(Long memberId) {
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
+		Member member = findMember(memberId);
 
 		return MemberConverter.toGetMemberResponseDTO(member);
+	}
+
+	public MemberResponseDTO.GetReportStats getReportStats(Long memberId) {
+		Record record = recordRepository.findByMemberId(memberId);
+
+		Map<SessionCategory, Integer> categoryCounts = record.getCategoryCounts();
+		List<MemberResponseDTO.SessionParticipationStat> sessionParticipationStats =
+			categoryCounts.entrySet().stream()
+				.map(entry -> MemberResponseDTO.SessionParticipationStat.builder()
+					.categoryName(entry.getKey())
+					.count(entry.getValue())
+					.rate(record.getCategoryParticipationRate(entry.getKey()))
+					.build()
+				)
+				.sorted(
+					Comparator.comparing(MemberResponseDTO.SessionParticipationStat::getCount)
+						.reversed()
+						.thenComparing(stat -> stat.getCategoryName().name())
+				)
+				.limit(4)
+				.toList();
+
+		Map<EmojiType, Integer> emojiTypeCounts = record.getEmojiTypeCounts();
+		List<MemberResponseDTO.ReceivedEmojiStat> receivedEmojiStats =
+			emojiTypeCounts.entrySet().stream()
+				.map(entry -> MemberResponseDTO.ReceivedEmojiStat.builder()
+					.emojiName(entry.getKey())
+					.count(entry.getValue())
+					.build()
+				)
+				.sorted(
+					Comparator.comparing(MemberResponseDTO.ReceivedEmojiStat::getCount)
+						.reversed()
+						.thenComparing(stat -> stat.getEmojiName().name())
+				)
+				.toList();
+
+		return MemberResponseDTO.GetReportStats.builder()
+			.focusedTime(record.getFocusedTime())
+			.totalParticipationTime(record.getTotalParticipationTime())
+			.todoCompletionRate(record.getTodoCompletionRate())
+			.focusRate(record.getFocusRate())
+			.sessionParticipationStats(sessionParticipationStats)
+			.receivedEmojis(receivedEmojiStats)
+			.build();
+	}
+
+	private Member findMember(Long memberId) {
+		return memberRepository.findById(memberId)
+			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_MEMBER));
 	}
 }

--- a/src/main/java/com/example/gak/domain/record/entity/Record.java
+++ b/src/main/java/com/example/gak/domain/record/entity/Record.java
@@ -1,6 +1,10 @@
 package com.example.gak.domain.record.entity;
 
+import java.util.EnumMap;
+import java.util.Map;
+
 import com.example.gak.domain.common.entity.BaseEntity;
+import com.example.gak.domain.common.entity.enums.EmojiType;
 import com.example.gak.domain.common.entity.enums.SessionCategory;
 import com.example.gak.domain.member.entity.Member;
 
@@ -52,6 +56,16 @@ public class Record extends BaseEntity {
 
 	private int etcSessionCount;
 
+	private int totalEmojiCount;
+
+	private int heartEmojiCount;
+
+	private int thumbsUpEmojiCount;
+
+	private int thumbsDownEmojiCount;
+
+	private int starEmojiCount;
+
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false, unique = true)
 	private Member member;
@@ -70,8 +84,17 @@ public class Record extends BaseEntity {
 		this.creativeSessionCount = 0;
 		this.teamProjectSessionCount = 0;
 		this.etcSessionCount = 0;
+		this.totalEmojiCount = 0;
+		this.heartEmojiCount = 0;
+		this.thumbsUpEmojiCount = 0;
+		this.thumbsDownEmojiCount = 0;
+		this.starEmojiCount = 0;
 		this.member = member;
 	}
+
+	/* =========================
+	 * 상태 변경 메서드 - 카운트 증가
+	 * ========================= */
 
 	public void increaseParticipationTime(long seconds) {
 		this.totalParticipationTime += seconds;
@@ -103,20 +126,28 @@ public class Record extends BaseEntity {
 		participationSessionCount++;
 	}
 
-	public int getTotalParticipationMinutes() {
-		return (int)Math.round(totalParticipationTime / 60.0);
+	public void increaseEmojiTypesCount(Map<EmojiType, Integer> emojiTypes) {
+		emojiTypes.forEach((type, count) -> {
+			switch (type) {
+				case HEART -> heartEmojiCount += count;
+				case THUMBS_UP -> thumbsUpEmojiCount += count;
+				case THUMBS_DOWN -> thumbsDownEmojiCount += count;
+				case STAR -> starEmojiCount += count;
+			}
+			totalEmojiCount += count;
+		});
 	}
 
-	public int getFocusedMinutes() {
-		return (int)Math.round(focusedTime / 60.0);
-	}
+	/* =========================
+	 * 비율 계산 메서드
+	 * ========================= */
 
 	public int getFocusRate() {
 		if (totalParticipationTime == 0) {
 			return 0;
 		}
 
-		return (int)((focusedTime * 100.0) / totalParticipationTime);
+		return (int)Math.round((focusedTime * 100.0) / totalParticipationTime);
 	}
 
 	public int getTodoCompletionRate() {
@@ -124,6 +155,59 @@ public class Record extends BaseEntity {
 			return 0;
 		}
 
-		return (int)((completedTodoCount * 100.0) / totalTodoCount);
+		return (int)Math.round((completedTodoCount * 100.0) / totalTodoCount);
+	}
+
+	public int getCategoryParticipationRate(SessionCategory category) {
+		if (participationSessionCount == 0) {
+			return 0;
+		}
+
+		int count = getCategoryCount(category);
+
+		return (int)Math.round((count * 100.0 / participationSessionCount));
+	}
+
+	/* =========================
+	 * 통계 조회 - 카테고리, 이모지
+	 * ========================= */
+
+	public Map<SessionCategory, Integer> getCategoryCounts() {
+		Map<SessionCategory, Integer> map = new EnumMap<>(SessionCategory.class);
+
+		map.put(SessionCategory.DEVELOPMENT, devSessionCount);
+		map.put(SessionCategory.DESIGN, designSessionCount);
+		map.put(SessionCategory.PLANNING_PM, planningPmSessionCount);
+		map.put(SessionCategory.CAREER_SELF_DEVELOPMENT, careerSelfDevSessionCount);
+		map.put(SessionCategory.STUDY_READING, studyReadingSessionCount);
+		map.put(SessionCategory.CREATIVE, creativeSessionCount);
+		map.put(SessionCategory.TEAM_PROJECT, teamProjectSessionCount);
+		map.put(SessionCategory.FREE, etcSessionCount);
+
+		return map;
+	}
+
+	public Map<EmojiType, Integer> getEmojiTypeCounts() {
+		Map<EmojiType, Integer> map = new EnumMap<>(EmojiType.class);
+
+		map.put(EmojiType.HEART, heartEmojiCount);
+		map.put(EmojiType.THUMBS_UP, thumbsUpEmojiCount);
+		map.put(EmojiType.THUMBS_DOWN, thumbsDownEmojiCount);
+		map.put(EmojiType.STAR, starEmojiCount);
+
+		return map;
+	}
+
+	private int getCategoryCount(SessionCategory category) {
+		return switch (category) {
+			case DEVELOPMENT -> devSessionCount;
+			case DESIGN -> designSessionCount;
+			case PLANNING_PM -> planningPmSessionCount;
+			case CAREER_SELF_DEVELOPMENT -> careerSelfDevSessionCount;
+			case STUDY_READING -> studyReadingSessionCount;
+			case CREATIVE -> creativeSessionCount;
+			case TEAM_PROJECT -> teamProjectSessionCount;
+			case FREE -> etcSessionCount;
+		};
 	}
 }

--- a/src/main/java/com/example/gak/domain/record/entity/Record.java
+++ b/src/main/java/com/example/gak/domain/record/entity/Record.java
@@ -175,14 +175,9 @@ public class Record extends BaseEntity {
 	public Map<SessionCategory, Integer> getCategoryCounts() {
 		Map<SessionCategory, Integer> map = new EnumMap<>(SessionCategory.class);
 
-		map.put(SessionCategory.DEVELOPMENT, devSessionCount);
-		map.put(SessionCategory.DESIGN, designSessionCount);
-		map.put(SessionCategory.PLANNING_PM, planningPmSessionCount);
-		map.put(SessionCategory.CAREER_SELF_DEVELOPMENT, careerSelfDevSessionCount);
-		map.put(SessionCategory.STUDY_READING, studyReadingSessionCount);
-		map.put(SessionCategory.CREATIVE, creativeSessionCount);
-		map.put(SessionCategory.TEAM_PROJECT, teamProjectSessionCount);
-		map.put(SessionCategory.FREE, etcSessionCount);
+		for (SessionCategory category : SessionCategory.values()) {
+			map.put(category, getCategoryCount(category));
+		}
 
 		return map;
 	}
@@ -190,10 +185,9 @@ public class Record extends BaseEntity {
 	public Map<EmojiType, Integer> getEmojiTypeCounts() {
 		Map<EmojiType, Integer> map = new EnumMap<>(EmojiType.class);
 
-		map.put(EmojiType.HEART, heartEmojiCount);
-		map.put(EmojiType.THUMBS_UP, thumbsUpEmojiCount);
-		map.put(EmojiType.THUMBS_DOWN, thumbsDownEmojiCount);
-		map.put(EmojiType.STAR, starEmojiCount);
+		for (EmojiType type : EmojiType.values()) {
+			map.put(type, getEmojiCount(type));
+		}
 
 		return map;
 	}
@@ -208,6 +202,15 @@ public class Record extends BaseEntity {
 			case CREATIVE -> creativeSessionCount;
 			case TEAM_PROJECT -> teamProjectSessionCount;
 			case FREE -> etcSessionCount;
+		};
+	}
+
+	private int getEmojiCount(EmojiType type) {
+		return switch (type) {
+			case HEART -> heartEmojiCount;
+			case THUMBS_UP -> thumbsUpEmojiCount;
+			case THUMBS_DOWN -> thumbsDownEmojiCount;
+			case STAR -> starEmojiCount;
 		};
 	}
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,9 +5,6 @@ spring:
     password: ${DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-    hikari:
-      leak-detection-threshold: 5000
-
   servlet:
     multipart:
       max-file-size: 5MB
@@ -30,7 +27,6 @@ spring:
         use_sql_comments: true
         jdbc:
           batch_size: 1000
-        generate_statistics: true
     open-in-view: false
 
   security:
@@ -76,10 +72,3 @@ cloud:
     credentials:
       accessKey: ${AWS_ACCESS_KEY_ID}
       secretKey: ${AWS_SECRET_ACCESS_KEY}
-
-logging:
-  level:
-    com.zaxxer.hikari: DEBUG
-    org.hibernate.SQL: DEBUG
-    org.hibernate.orm.jdbc.bind: TRACE
-    org.springframework.transaction: DEBUG


### PR DESCRIPTION
## 작업 내용

> - 회원 리포트 통계 데이터 조회 API 구현

## 참고 사항

> - Record 엔티티 클래스 스펙 변경
>   - 이모지 관련 필드 및 메서드 추가
>   - 세션 카테고리, 이모지 타입에 대한 카운트 현황 데이터(Map) 조회 메서드 추가

## 연관 이슈

> close #44