### PR TITLE
feat: 세션 집중 시간 서버 측 계산 방식으로 변경

### DIFF
--- a/src/main/java/com/example/gak/domain/session/controller/SessionController.java
+++ b/src/main/java/com/example/gak/domain/session/controller/SessionController.java
@@ -165,6 +165,10 @@ public class SessionController {
 		return ApiResponse.onSuccess(null);
 	}
 
+	/**
+	 * @deprecated 세션 집중 시간 계산 책임 서버 측으로 변경
+	 */
+	@Deprecated
 	@Operation(summary = "세션 종료 후 결과 전송 API")
 	@PostMapping("/{sessionId}/results")
 	public ApiResponse<Void> postSessionResult(
@@ -172,7 +176,7 @@ public class SessionController {
 		@AuthenticationPrincipal CustomOAuth2User oAuth2User,
 		@RequestBody @Valid SessionRequestDTO.SessionResultRequestDTO request
 	) {
-		sessionCommandService.postSessionResult(oAuth2User.getMemberId(), sessionId, request);
+		// sessionCommandService.postSessionResult(oAuth2User.getMemberId(), sessionId, request);
 		return ApiResponse.onSuccess(null);
 	}
 

--- a/src/main/java/com/example/gak/domain/session/entity/SessionRoomMember.java
+++ b/src/main/java/com/example/gak/domain/session/entity/SessionRoomMember.java
@@ -1,5 +1,6 @@
 package com.example.gak.domain.session.entity;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.example.gak.domain.common.entity.BaseEntity;
@@ -61,6 +62,8 @@ public class SessionRoomMember extends BaseEntity {
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
 
+	private LocalDateTime lastFocusTime = LocalDateTime.now();
+
 	private Integer totalFocusSeconds = 0;
 
 	private Integer overallSeconds = 0;
@@ -120,6 +123,14 @@ public class SessionRoomMember extends BaseEntity {
 
 	public void setTotalFocusSeconds(int totalFocusSeconds) {
 		this.totalFocusSeconds = totalFocusSeconds;
+	}
+
+	public void updateFocusSeconds(int focusSeconds) {
+		this.totalFocusSeconds += focusSeconds;
+	}
+
+	public void setLastFocusTime(LocalDateTime lastFocusTime) {
+		this.lastFocusTime = lastFocusTime;
 	}
 
 	public void setOverallSeconds(int overallSeconds) {

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -335,6 +335,23 @@ public class SessionCommandService {
 				).getSeconds();
 				member.updateFocusSeconds(seconds);
 			}
+
+			member.setOverallSeconds(
+				(int)Duration.between(
+					member.getCreatedAt(),
+					sessionRoom.getEndTime()
+				).getSeconds()
+			);
+
+			member.updateFocusRate();
+
+			Task task = taskRepository.findWithSessionRoomBySessionRoomIdAndMemberId(sessionId,
+					sessionRoom.getMember().getId())
+				.orElseThrow(() -> new GeneralException(GeneralErrorCode.TASK_NOT_FOUND_IN_SESSION));
+			List<SubTask> subTasks = subTaskRepository.findByTaskId(task.getId());
+
+			member.updateAchievementRate(subTasks);
+			sessionSaveToRecord(member.getMember(), member, subTasks);
 		}
 
 		applicationEventPublisher.publishEvent(

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -4,6 +4,7 @@ import static com.example.gak.domain.session.converter.SessionConverter.*;
 import static com.example.gak.domain.session.entity.enums.SessionRoomStatus.*;
 import static com.example.gak.global.apiPayload.code.GeneralErrorCode.*;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -29,6 +30,7 @@ import com.example.gak.domain.session.entity.Reaction;
 import com.example.gak.domain.session.entity.SessionRoom;
 import com.example.gak.domain.session.entity.SessionRoomMember;
 import com.example.gak.domain.session.entity.enums.SessionParticipantRole;
+import com.example.gak.domain.session.entity.enums.SessionParticipantStatus;
 import com.example.gak.domain.session.entity.enums.SessionRoomStatus;
 import com.example.gak.domain.session.repository.ReactionRepository;
 import com.example.gak.domain.session.repository.SessionRoomMemberRepository;
@@ -230,6 +232,17 @@ public class SessionCommandService {
 
 		sessionRoomMember.toggleStatus();
 
+		if (sessionRoomMember.getStatus() == SessionParticipantStatus.REST) {
+			int seconds = (int)Duration.between(
+				sessionRoomMember.getLastFocusTime(),
+				LocalDateTime.now()
+			).getSeconds();
+
+			sessionRoomMember.updateFocusSeconds(seconds);
+		} else if (sessionRoomMember.getStatus() == SessionParticipantStatus.FOCUSED) {
+			sessionRoomMember.setLastFocusTime(LocalDateTime.now());
+		}
+
 		publishSessionRoomUpdateEvent(
 			sessionRoomMember.getSessionRoom().getStatus(),
 			sessionId
@@ -294,6 +307,11 @@ public class SessionCommandService {
 			sessionRoom.changeStatus(SessionRoomStatus.IN_PROGRESS);
 		}
 
+		List<SessionRoomMember> sessionRoomMembers = sessionRoom.getSessionRoomMembers();
+		for (SessionRoomMember member : sessionRoomMembers) {
+			member.setLastFocusTime(LocalDateTime.now());
+		}
+
 		applicationEventPublisher.publishEvent(
 			new SessionStatusUpdateEvent(sessionId)
 		);
@@ -305,6 +323,18 @@ public class SessionCommandService {
 
 		if (sessionRoom.getStatus() == SessionRoomStatus.IN_PROGRESS) {
 			sessionRoom.changeStatus(SessionRoomStatus.COMPLETED);
+		}
+
+		List<SessionRoomMember> sessionRoomMembers = sessionRoom.getSessionRoomMembers();
+
+		for (SessionRoomMember member : sessionRoomMembers) {
+			if (member.getStatus() == SessionParticipantStatus.FOCUSED) {
+				int seconds = (int)Duration.between(
+					member.getLastFocusTime(),
+					sessionRoom.getEndTime()
+				).getSeconds();
+				member.updateFocusSeconds(seconds);
+			}
 		}
 
 		applicationEventPublisher.publishEvent(


### PR DESCRIPTION
## 작업 내용

> - 기존에는 세션 결과 전송 API를 통해 프론트엔드로부터 세션 집중 시간을 전달받았으나, 이를 서버 측에서 전부 관리하는 구조로 변경하였습니다. 이로 인해 모든 참여자의 집중 시간이 수집되기 전에 세션 결과 조회 API가 호출되면서 발생하던 문제를 개선하였습니다.
> - 세션 결과 전송 API가 deprecated 처리 되었습니다.

## 참고 사항

> 

## 연관 이슈

> close #115 


<br>