### PR TITLE
feat: 강퇴 이벤트 SSE 발송

### DIFF
--- a/src/main/java/com/example/gak/domain/session/converter/SessionConverter.java
+++ b/src/main/java/com/example/gak/domain/session/converter/SessionConverter.java
@@ -202,6 +202,14 @@ public class SessionConverter {
 			.build();
 	}
 
+	public static SessionResponseDTO.KickedUserResponseDTO toKickedUserResponseDTO(
+		List<Long> memberIds
+	) {
+		return SessionResponseDTO.KickedUserResponseDTO.builder()
+			.memberIds(memberIds)
+			.build();
+	}
+
 	public static SessionResponseDTO.EmojiResultResponseDTO toEmojiResultResponseDTO(
 		SessionRoomMember sessionRoomMember
 	) {

--- a/src/main/java/com/example/gak/domain/session/dto/SessionResponseDTO.java
+++ b/src/main/java/com/example/gak/domain/session/dto/SessionResponseDTO.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.example.gak.domain.common.entity.enums.EmojiType;
+import com.example.gak.domain.session.dto.enums.EventType;
 import com.example.gak.domain.session.entity.enums.SessionParticipantRole;
 import com.example.gak.domain.session.entity.enums.SessionParticipantStatus;
 import com.example.gak.domain.session.entity.enums.SessionRoomStatus;
@@ -116,6 +117,21 @@ public class SessionResponseDTO {
 	public static class WaitingResponseDTO {
 		private Integer participantCount;
 		private List<WaitingMemberResponseDTO> members;
+	}
+
+	@Schema(name = "사용자 강퇴 이벤트 응답")
+	@Builder
+	@Getter
+	public static class KickedUserResponseDTO {
+		private List<Long> memberIds;
+	}
+
+	@Schema(name = "대기방 SSE 이벤트 응답")
+	@Builder
+	@Getter
+	public static class SessionWaitingRoomResponseDTO<T> {
+		private EventType eventType;
+		private T data;
 	}
 
 	@Schema(name = "세션 진행 중 참여자 상태 토글 응답")

--- a/src/main/java/com/example/gak/domain/session/dto/enums/EventType.java
+++ b/src/main/java/com/example/gak/domain/session/dto/enums/EventType.java
@@ -1,0 +1,6 @@
+package com.example.gak.domain.session.dto.enums;
+
+public enum EventType {
+	ROOM_UPDATE,
+	KICKED
+}

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -44,6 +44,7 @@ import com.example.gak.global.apiPayload.exception.GeneralException;
 import com.example.gak.global.aws.AmazonS3Manager;
 import com.example.gak.global.redis.RedisPublisher;
 import com.example.gak.global.redis.event.InProgressRoomUpdateEvent;
+import com.example.gak.global.redis.event.MemberKickedEvent;
 import com.example.gak.global.redis.event.MemberReactionUpdateEvent;
 import com.example.gak.global.redis.event.ReactionUpdateEvent;
 import com.example.gak.global.redis.event.SessionStatusUpdateEvent;
@@ -292,6 +293,11 @@ public class SessionCommandService {
 		if (updated == 0) {
 			throw new GeneralException(GeneralErrorCode.SESSION_INVALID_STATE);
 		}
+
+		publishSessionRoomKickedMemberEvent(
+			sessionId,
+			targetMemberIds
+		);
 
 		publishSessionRoomUpdateEvent(
 			sessionRoom.getStatus(),
@@ -631,5 +637,11 @@ public class SessionCommandService {
 				new WaitingRoomUpdateEvent(sessionId)
 			);
 		}
+	}
+
+	private void publishSessionRoomKickedMemberEvent(Long sessionId, List<Long> memberIds) {
+		applicationEventPublisher.publishEvent(
+			new MemberKickedEvent(sessionId, memberIds)
+		);
 	}
 }

--- a/src/main/java/com/example/gak/global/redis/RedisConfig.java
+++ b/src/main/java/com/example/gak/global/redis/RedisConfig.java
@@ -32,6 +32,7 @@ public class RedisConfig {
 
 		container.setConnectionFactory(connectionFactory);
 		container.addMessageListener(redisSubscriber, new PatternTopic("waiting/*"));
+		container.addMessageListener(redisSubscriber, new PatternTopic("kicked/*"));
 		container.addMessageListener(redisSubscriber, new PatternTopic("in-progress/*"));
 		container.addMessageListener(redisSubscriber, new PatternTopic("session/*"));
 		container.addMessageListener(redisSubscriber, new PatternTopic("reaction/*"));

--- a/src/main/java/com/example/gak/global/redis/RedisPublisher.java
+++ b/src/main/java/com/example/gak/global/redis/RedisPublisher.java
@@ -1,10 +1,14 @@
 package com.example.gak.global.redis;
 
+import java.util.List;
+
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import com.example.gak.domain.chat.dto.ChatResponseDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,12 +20,26 @@ public class RedisPublisher {
 
 	private final StringRedisTemplate redisTemplate;
 	private final RedisTemplate<String, Object> chatRedisTemplate;
+	private final ObjectMapper objectMapper;
 
 	public void waitingRoomPublish(
 		Long sessionId
 	) {
 		String channel = "waiting/" + sessionId;
 		redisTemplate.convertAndSend(channel, "UPDATE");
+	}
+
+	public void kickedPublish(
+		Long sessionId,
+		List<Long> memberIds
+	) {
+		String channel = "kicked/" + sessionId;
+		try {
+			String message = objectMapper.writeValueAsString(memberIds);
+			redisTemplate.convertAndSend(channel, message);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	public void inProgressRoomPublish(

--- a/src/main/java/com/example/gak/global/redis/RedisPublisher.java
+++ b/src/main/java/com/example/gak/global/redis/RedisPublisher.java
@@ -38,7 +38,7 @@ public class RedisPublisher {
 			String message = objectMapper.writeValueAsString(memberIds);
 			redisTemplate.convertAndSend(channel, message);
 		} catch (JsonProcessingException e) {
-			throw new RuntimeException(e);
+			log.error("강퇴 이벤트 메시지 직렬화 실패", e);
 		}
 	}
 

--- a/src/main/java/com/example/gak/global/redis/RedisSubscriber.java
+++ b/src/main/java/com/example/gak/global/redis/RedisSubscriber.java
@@ -75,8 +75,15 @@ public class RedisSubscriber implements MessageListener {
 	}
 
 	private void handleWaiting(Long sessionId) {
-		SessionResponseDTO.WaitingResponseDTO dto =
+		SessionResponseDTO.WaitingResponseDTO waitingResponseDTO =
 			sessionQueryService.getCurrentWaitingRoom(sessionId);
+
+		SessionResponseDTO.SessionWaitingRoomResponseDTO<SessionResponseDTO.WaitingResponseDTO> dto =
+			SessionResponseDTO.SessionWaitingRoomResponseDTO.<SessionResponseDTO.WaitingResponseDTO>builder()
+				.eventType(EventType.ROOM_UPDATE)
+				.data(waitingResponseDTO)
+				.build();
+
 		sseService.sendWaiting(sessionId, dto);
 	}
 

--- a/src/main/java/com/example/gak/global/redis/RedisSubscriber.java
+++ b/src/main/java/com/example/gak/global/redis/RedisSubscriber.java
@@ -50,9 +50,7 @@ public class RedisSubscriber implements MessageListener {
 			handleChatMessage(sessionId, json);
 		} else if ("kicked".equals(type)) {
 			Long sessionId = Long.parseLong(parts[1]);
-			log.info("channel={}", channel);
 			String json = new String(message.getBody(), java.nio.charset.StandardCharsets.UTF_8);
-			log.info("kicked payload={}", json);
 			try {
 				handleKicked(sessionId, json);
 			} catch (JsonProcessingException e) {

--- a/src/main/java/com/example/gak/global/redis/RedisSubscriber.java
+++ b/src/main/java/com/example/gak/global/redis/RedisSubscriber.java
@@ -50,7 +50,7 @@ public class RedisSubscriber implements MessageListener {
 			try {
 				handleKicked(sessionId, json);
 			} catch (JsonProcessingException e) {
-				throw new RuntimeException(e);
+				log.error("강퇴 이벤트 메시지 역직렬화 실패", e);
 			}
 		} else {
 			Long sessionId = Long.parseLong(parts[1]);

--- a/src/main/java/com/example/gak/global/redis/RedisSubscriber.java
+++ b/src/main/java/com/example/gak/global/redis/RedisSubscriber.java
@@ -1,14 +1,22 @@
 package com.example.gak.global.redis;
 
+import java.util.List;
+
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
+import com.example.gak.domain.session.converter.SessionConverter;
 import com.example.gak.domain.session.dto.SessionResponseDTO;
+import com.example.gak.domain.session.dto.enums.EventType;
+import com.example.gak.domain.session.service.SessionCommandService;
 import com.example.gak.domain.session.service.SessionQueryService;
 import com.example.gak.global.sse.SseService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +30,8 @@ public class RedisSubscriber implements MessageListener {
 	private final SseService sseService;
 	private final SimpMessagingTemplate messagingTemplate;
 	private final StringRedisTemplate redisTemplate;
+	private final SessionCommandService sessionCommandService;
+	private final ObjectMapper objectMapper;
 
 	@Override
 	public void onMessage(Message message, byte[] pattern) {
@@ -38,6 +48,16 @@ public class RedisSubscriber implements MessageListener {
 			Long sessionId = Long.parseLong(parts[1]);
 			String json = new String(message.getBody(), java.nio.charset.StandardCharsets.UTF_8);
 			handleChatMessage(sessionId, json);
+		} else if ("kicked".equals(type)) {
+			Long sessionId = Long.parseLong(parts[1]);
+			log.info("channel={}", channel);
+			String json = new String(message.getBody(), java.nio.charset.StandardCharsets.UTF_8);
+			log.info("kicked payload={}", json);
+			try {
+				handleKicked(sessionId, json);
+			} catch (JsonProcessingException e) {
+				throw new RuntimeException(e);
+			}
 		} else {
 			Long sessionId = Long.parseLong(parts[1]);
 			handleMessage(type, sessionId);
@@ -57,6 +77,17 @@ public class RedisSubscriber implements MessageListener {
 	private void handleWaiting(Long sessionId) {
 		SessionResponseDTO.WaitingResponseDTO dto =
 			sessionQueryService.getCurrentWaitingRoom(sessionId);
+		sseService.sendWaiting(sessionId, dto);
+	}
+
+	private void handleKicked(Long sessionId, String json) throws JsonProcessingException {
+		List<Long> memberIds = objectMapper.readValue(
+			json,
+			new TypeReference<List<Long>>() {
+			}
+		);
+		SessionResponseDTO.SessionWaitingRoomResponseDTO<SessionResponseDTO.KickedUserResponseDTO> dto =
+			getKickedUserInfo(memberIds);
 		sseService.sendWaiting(sessionId, dto);
 	}
 
@@ -86,5 +117,16 @@ public class RedisSubscriber implements MessageListener {
 
 	private void handleChatMessage(Long sessionId, String json) {
 		messagingTemplate.convertAndSend("/sub/chat/" + sessionId, json);
+	}
+
+	private SessionResponseDTO.SessionWaitingRoomResponseDTO<SessionResponseDTO.KickedUserResponseDTO> getKickedUserInfo(
+		List<Long> memberIds) {
+		SessionResponseDTO.KickedUserResponseDTO kickedUserResponseDTO
+			= SessionConverter.toKickedUserResponseDTO(memberIds);
+
+		return SessionResponseDTO.SessionWaitingRoomResponseDTO.<SessionResponseDTO.KickedUserResponseDTO>builder()
+			.eventType(EventType.KICKED)
+			.data(kickedUserResponseDTO)
+			.build();
 	}
 }

--- a/src/main/java/com/example/gak/global/redis/RedisSubscriber.java
+++ b/src/main/java/com/example/gak/global/redis/RedisSubscriber.java
@@ -4,14 +4,12 @@ import java.util.List;
 
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
 import com.example.gak.domain.session.converter.SessionConverter;
 import com.example.gak.domain.session.dto.SessionResponseDTO;
 import com.example.gak.domain.session.dto.enums.EventType;
-import com.example.gak.domain.session.service.SessionCommandService;
 import com.example.gak.domain.session.service.SessionQueryService;
 import com.example.gak.global.sse.SseService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -29,8 +27,6 @@ public class RedisSubscriber implements MessageListener {
 	private final SessionQueryService sessionQueryService;
 	private final SseService sseService;
 	private final SimpMessagingTemplate messagingTemplate;
-	private final StringRedisTemplate redisTemplate;
-	private final SessionCommandService sessionCommandService;
 	private final ObjectMapper objectMapper;
 
 	@Override

--- a/src/main/java/com/example/gak/global/redis/event/MemberKickedEvent.java
+++ b/src/main/java/com/example/gak/global/redis/event/MemberKickedEvent.java
@@ -1,0 +1,6 @@
+package com.example.gak.global.redis.event;
+
+import java.util.List;
+
+public record MemberKickedEvent(Long sessionId, List<Long> memberIds) {
+}

--- a/src/main/java/com/example/gak/global/redis/eventHandler/MemberKickedEventHandler.java
+++ b/src/main/java/com/example/gak/global/redis/eventHandler/MemberKickedEventHandler.java
@@ -1,0 +1,22 @@
+package com.example.gak.global.redis.eventHandler;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.example.gak.global.redis.RedisPublisher;
+import com.example.gak.global.redis.event.MemberKickedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MemberKickedEventHandler {
+
+	private final RedisPublisher redisPublisher;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(MemberKickedEvent event) {
+		redisPublisher.kickedPublish(event.sessionId(), event.memberIds());
+	}
+}


### PR DESCRIPTION
## 작업 내용

> 강퇴 이벤트 발생 시, 기존 대기방 SSE 채널에 전송하도록 구현하였습니다. 기존 대기방 SSE 채널의 공통 응답 형식에 변화가 생겼습니다.

## 참고 사항

>

## 연관 이슈

> close #117 


<br>