### PR TITLE
feat: SSE 초기 연결 시 단일 emitter 전송 메서드 추가

### DIFF
--- a/src/main/java/com/example/gak/domain/session/controller/SessionSseController.java
+++ b/src/main/java/com/example/gak/domain/session/controller/SessionSseController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import com.example.gak.domain.session.dto.SessionResponseDTO;
+import com.example.gak.domain.session.dto.enums.EventType;
 import com.example.gak.domain.session.service.SessionQueryService;
 import com.example.gak.global.sse.SseService;
 
@@ -30,8 +32,12 @@ public class SessionSseController {
 		SseEmitter emitter = sseService.subscribeWaiting(sessionId);
 
 		try {
-			sseService.sendWaiting(sessionId,
-				sessionQueryService.getCurrentWaitingRoom(sessionId));
+			SessionResponseDTO.SessionWaitingRoomResponseDTO<SessionResponseDTO.WaitingResponseDTO> dto =
+				SessionResponseDTO.SessionWaitingRoomResponseDTO.<SessionResponseDTO.WaitingResponseDTO>builder()
+					.eventType(EventType.ROOM_UPDATE)
+					.data(sessionQueryService.getCurrentWaitingRoom(sessionId))
+					.build();
+			sseService.sendToWaitingEmitter(emitter, dto);
 		} catch (Exception e) {
 			emitter.completeWithError(e);
 		}
@@ -46,7 +52,7 @@ public class SessionSseController {
 		SseEmitter emitter = sseService.subscribeInProgress(sessionId);
 
 		try {
-			sseService.sendInProgress(sessionId,
+			sseService.sendToInProgressEmitter(emitter,
 				sessionQueryService.getCurrentSessionRoom(sessionId));
 		} catch (Exception e) {
 			emitter.completeWithError(e);
@@ -62,8 +68,8 @@ public class SessionSseController {
 		SseEmitter emitter = sseService.subscribeSessionStatus(sessionId);
 
 		try {
-			sseService.sendSessionStatus(
-				sessionId,
+			sseService.sendToSessionStatusEmitter(
+				emitter,
 				sessionQueryService.getSessionStatus(sessionId)
 			);
 		} catch (Exception e) {
@@ -80,8 +86,8 @@ public class SessionSseController {
 		SseEmitter emitter = sseService.subscribeReaction(sessionId);
 
 		try {
-			sseService.sendReaction(
-				sessionId,
+			sseService.sendToReactionEmitter(
+				emitter,
 				sessionQueryService.getReactionStatus(sessionId)
 			);
 		} catch (Exception e) {

--- a/src/main/java/com/example/gak/global/sse/SseService.java
+++ b/src/main/java/com/example/gak/global/sse/SseService.java
@@ -52,6 +52,12 @@ public class SseService {
 		}
 	}
 
+	public void sendToWaitingEmitter(SseEmitter emitter, Object data) throws IOException {
+		emitter.send(SseEmitter.event()
+			.name("waiting-members-updated")
+			.data(data));
+	}
+
 	private void removeWaitingEmitter(Long sessionId, SseEmitter emitter) {
 		List<SseEmitter> emitters = waitingEmitters.get(sessionId);
 		if (emitters != null) {
@@ -88,6 +94,12 @@ public class SseService {
 				removeInProgressEmitter(sessionId, emitter);
 			}
 		}
+	}
+
+	public void sendToInProgressEmitter(SseEmitter emitter, Object data) throws IOException {
+		emitter.send(SseEmitter.event()
+			.name("in-progress-members-updated")
+			.data(data));
 	}
 
 	private void removeInProgressEmitter(Long sessionId, SseEmitter emitter) {
@@ -128,6 +140,12 @@ public class SseService {
 		}
 	}
 
+	public void sendToSessionStatusEmitter(SseEmitter emitter, Object data) throws IOException {
+		emitter.send(SseEmitter.event()
+			.name("session-status-updated")
+			.data(data));
+	}
+
 	private void removeSessionStatusEmitter(Long sessionId, SseEmitter emitter) {
 		List<SseEmitter> emitters = sessionStatusEmitters.get(sessionId);
 		if (emitters != null) {
@@ -164,6 +182,12 @@ public class SseService {
 				removeReactionEmitter(sessionId, emitter);
 			}
 		}
+	}
+
+	public void sendToReactionEmitter(SseEmitter emitter, Object data) throws IOException {
+		emitter.send(SseEmitter.event()
+			.name("reaction-updated")
+			.data(data));
 	}
 
 	private void removeReactionEmitter(Long sessionId, SseEmitter emitter) {


### PR DESCRIPTION
## 작업 내용

>  1. 대기방 SSE의 초기 연결 데이터와 후속 수신 데이터의 스키마가 다른 문제를 수정했습니다.
>  2. 다른 SSE 채널들에 새로운 Emitter가 추가 될 때, 초기 데이터를 모든 연결되어있는 Emitter들에게 브로드 캐스트하던 문제를 수정했습니다.

## 참고 사항

> 

## 연관 이슈

> close #120 


<br>