### PR TITLE
refactor: 세션 정원 세션 생성자 예약석 로직 추가

### DIFF
--- a/src/main/java/com/example/gak/domain/session/repository/SessionRoomRepository.java
+++ b/src/main/java/com/example/gak/domain/session/repository/SessionRoomRepository.java
@@ -32,8 +32,19 @@ public interface SessionRoomRepository extends JpaRepository<SessionRoom, Long>,
 		    WHERE s.id = :sessionId
 		      AND s.currentCount < s.maxCapacity
 		      AND s.status <> com.example.gak.domain.session.entity.enums.SessionRoomStatus.COMPLETED
+		      AND (
+		        s.status <> com.example.gak.domain.session.entity.enums.SessionRoomStatus.WAITING
+		        OR s.member.id = :memberId
+		        OR EXISTS (
+		          SELECT 1
+		          FROM SessionRoomMember srm
+		          WHERE srm.sessionRoom = s
+		            AND srm.member = s.member
+		        )
+		        OR s.currentCount < s.maxCapacity - 1
+		      )
 		""")
-	int increaseCountIfAvailable(@Param("sessionId") Long sessionId);
+	int increaseCountIfJoinable(@Param("sessionId") Long sessionId, @Param("memberId") Long memberId);
 
 	@Modifying(clearAutomatically = true)
 	@Query("""

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -150,22 +150,16 @@ public class SessionCommandService {
 		SessionRoom sessionRoom,
 		List<SessionRoomMember> members
 	) {
+		boolean isRoomOwner = member.getId().equals(sessionRoom.getMember().getId());
+
+		if (sessionRoom.getStatus() == WAITING) {
+			return isRoomOwner ? SessionParticipantRole.HOST : SessionParticipantRole.PARTICIPANT;
+		}
+
 		boolean hasHost = members.stream()
 			.anyMatch(m -> m.getRole() == SessionParticipantRole.HOST);
 
-		if (hasHost) {
-			return SessionParticipantRole.PARTICIPANT;
-		}
-
-		boolean isWaiting = sessionRoom.getStatus() == WAITING;
-		boolean isRoomOwner = member.getId().equals(sessionRoom.getMember().getId());
-		boolean isFirstJoiner = members.isEmpty();
-
-		if (isWaiting && isRoomOwner) {
-			return SessionParticipantRole.HOST;
-		}
-
-		if (!isWaiting && isFirstJoiner) {
+		if (!hasHost && members.isEmpty()) {
 			return SessionParticipantRole.HOST;
 		}
 

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -158,10 +158,7 @@ public class SessionCommandService {
 			return isRoomOwner ? SessionParticipantRole.HOST : SessionParticipantRole.PARTICIPANT;
 		}
 
-		boolean hasHost = members.stream()
-			.anyMatch(m -> m.getRole() == SessionParticipantRole.HOST);
-
-		if (!hasHost && members.isEmpty()) {
+		if (members.isEmpty()) {
 			return SessionParticipantRole.HOST;
 		}
 

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -130,9 +130,11 @@ public class SessionCommandService {
 		SessionRoom targetSessionRoom = sessionRoomRepository.findWithMemberById(sessionId)
 			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_SESSION));
 
-		List<SessionRoomMember> sessionRoomMembers = sessionRoomMemberRepository.findBySessionRoom(targetSessionRoom);
+		increaseCountOrThrow(targetSessionRoom, memberId);
 
-		increaseCountOrThrow(targetSessionRoom);
+		List<SessionRoomMember> sessionRoomMembers
+			= sessionRoomMemberRepository.findBySessionRoom(targetSessionRoom);
+
 		SessionParticipantRole role = determineRole(member, targetSessionRoom, sessionRoomMembers);
 		SessionRoomMember sessionRoomMember = saveSessionRoomMember(targetSessionRoom, member, role);
 		SessionResponseDTO.taskResponseDTO taskResponseDTO = saveGoalTask(targetSessionRoom, member, request);
@@ -605,8 +607,8 @@ public class SessionCommandService {
 		return toTaskResponseDTO(list, newTask);
 	}
 
-	private void increaseCountOrThrow(SessionRoom targetSessionRoom) {
-		int updated = sessionRoomRepository.increaseCountIfAvailable(targetSessionRoom.getId());
+	private void increaseCountOrThrow(SessionRoom targetSessionRoom, Long memberId) {
+		int updated = sessionRoomRepository.increaseCountIfJoinable(targetSessionRoom.getId(), memberId);
 		if (updated == 0) {
 			SessionRoom currentSessionRoom = sessionRoomRepository.findById(targetSessionRoom.getId())
 				.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_SESSION));

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -199,6 +199,13 @@ public class SessionCommandService {
 	}
 
 	private void hostPermissionTransfer(Long sessionId) {
+		SessionRoom sessionRoom = sessionRoomRepository.findById(sessionId)
+			.orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND_SESSION));
+
+		if (sessionRoom.getStatus() != SessionRoomStatus.IN_PROGRESS) {
+			return;
+		}
+
 		List<SessionRoomMember> members =
 			sessionRoomMemberRepository.findBySessionRoomId(sessionId);
 


### PR DESCRIPTION
## 작업 내용

> - 세션 정원 세션 생성자 예약석 로직이 추가되었습니다.
> - 현재 WAITING 상태에서는 일반 참가자가 방 정원을 끝까지 다 채워버릴 수 있습니다. 그러면 세션 생성자(대기방에서 HOST가 되어야 하는 사람)가 나중에 들어오지 못하는 문제가 생깁니다. 따라서 WAITING 상태일 때만, 세션 생성자가 아직 입장하지 않은 경우, 해당 인원을 위한 1자리를 예약합니다.

## 참고 사항

> 

## 연관 이슈

> close #119


<br>