### PR TITLE
refactor: 채팅 메시지 발행을 @TransactionalEventListener 패턴으로 변경

### DIFF
--- a/src/main/java/com/example/gak/domain/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/com/example/gak/domain/chat/controller/ChatWebSocketController.java
@@ -1,14 +1,19 @@
 package com.example.gak.domain.chat.controller;
 
 import java.security.Principal;
+import java.util.stream.Collectors;
 
 import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
 import org.springframework.stereotype.Controller;
 
 import com.example.gak.domain.chat.dto.ChatRequestDTO;
+import com.example.gak.domain.chat.dto.ChatResponseDTO;
 import com.example.gak.domain.chat.service.ChatCommandService;
 import com.example.gak.global.webSocket.StompPrincipal;
 
@@ -31,6 +36,18 @@ public class ChatWebSocketController {
 	) {
 		Long memberId = extractMemberId(principal);
 		chatCommandService.sendMessage(sessionId, memberId, message);
+	}
+
+	@MessageExceptionHandler(MethodArgumentNotValidException.class)
+	@SendToUser("/queue/chat/error")
+	public ChatResponseDTO.ChatErrorResponseDTO handleValidationException(MethodArgumentNotValidException e) {
+		String message = e.getBindingResult().getFieldErrors().stream()
+			.map(fieldError -> fieldError.getDefaultMessage())
+			.collect(Collectors.joining(", "));
+		return ChatResponseDTO.ChatErrorResponseDTO.builder()
+			.code("CHAT400")
+			.message(message)
+			.build();
 	}
 
 	private Long extractMemberId(Principal principal) {

--- a/src/main/java/com/example/gak/domain/chat/dto/ChatRequestDTO.java
+++ b/src/main/java/com/example/gak/domain/chat/dto/ChatRequestDTO.java
@@ -17,20 +17,20 @@ public class ChatRequestDTO {
 	@AllArgsConstructor
 	@Builder
 	public static class SendChatMessageRequestDTO {
-		@Size(min = 1, max = 200)
+		@Size(max = 200, message = "채팅 내용은 200자 이하로 입력해주세요.")
 		private String content;
 
-		@NotNull
+		@NotNull(message = "메시지 유형을 선택해주세요.")
 		private ChatMessageType type;
 
 		private QuickActionType quickActionType;
 
-		@AssertTrue(message = "일반 채팅은 content가 필요합니다.")
+		@AssertTrue(message = "채팅 내용을 입력해주세요.")
 		public boolean isValidTextMessage() {
 			return type != ChatMessageType.TEXT || (content != null && !content.isBlank());
 		}
 
-		@AssertTrue(message = "퀵메시지는 quickActionType이 필요합니다.")
+		@AssertTrue(message = "퀵 액션을 선택해주세요.")
 		public boolean isValidQuickActionMessage() {
 			return type != ChatMessageType.QUICK_ACTION || quickActionType != null;
 		}

--- a/src/main/java/com/example/gak/domain/chat/service/ChatCommandService.java
+++ b/src/main/java/com/example/gak/domain/chat/service/ChatCommandService.java
@@ -2,6 +2,7 @@ package com.example.gak.domain.chat.service;
 
 import static com.example.gak.domain.chat.converter.ChatConverter.*;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,7 +13,7 @@ import com.example.gak.domain.member.entity.Member;
 import com.example.gak.domain.member.repository.MemberRepository;
 import com.example.gak.domain.session.entity.SessionRoom;
 import com.example.gak.domain.session.repository.SessionRoomRepository;
-import com.example.gak.global.redis.RedisPublisher;
+import com.example.gak.global.redis.event.ChatMessageEvent;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ChatCommandService {
 
-	private final RedisPublisher redisPublisher;
+	private final ApplicationEventPublisher eventPublisher;
 	private final ChatMessageRepository chatMessageRepository;
 	private final SessionRoomRepository sessionRoomRepository;
 	private final MemberRepository memberRepository;
@@ -30,14 +31,6 @@ public class ChatCommandService {
 		SessionRoom sessionRoom = sessionRoomRepository.getReferenceById(sessionId);
 		Member member = memberRepository.getReferenceById(memberId);
 
-		redisPublisher.chatMessagePublish(
-			sessionId,
-			toChatMessageResponseDTO(
-				memberId,
-				dto.getContent(),
-				dto.getType(),
-				dto.getQuickActionType()));
-
 		chatMessageRepository.save(new ChatMessage(
 			dto.getContent(),
 			dto.getType(),
@@ -45,5 +38,13 @@ public class ChatCommandService {
 			sessionRoom,
 			member
 		));
+
+		eventPublisher.publishEvent(new ChatMessageEvent(
+			sessionId,
+			toChatMessageResponseDTO(
+				memberId,
+				dto.getContent(),
+				dto.getType(),
+				dto.getQuickActionType())));
 	}
 }

--- a/src/main/java/com/example/gak/global/redis/event/ChatMessageEvent.java
+++ b/src/main/java/com/example/gak/global/redis/event/ChatMessageEvent.java
@@ -1,0 +1,6 @@
+package com.example.gak.global.redis.event;
+
+import com.example.gak.domain.chat.dto.ChatResponseDTO;
+
+public record ChatMessageEvent(Long sessionId, ChatResponseDTO.ChatMessageResponseDTO dto) {
+}

--- a/src/main/java/com/example/gak/global/redis/eventHandler/ChatMessageEventHandler.java
+++ b/src/main/java/com/example/gak/global/redis/eventHandler/ChatMessageEventHandler.java
@@ -8,7 +8,9 @@ import com.example.gak.global.redis.RedisPublisher;
 import com.example.gak.global.redis.event.ChatMessageEvent;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ChatMessageEventHandler {
@@ -17,6 +19,10 @@ public class ChatMessageEventHandler {
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(ChatMessageEvent event) {
-		redisPublisher.chatMessagePublish(event.sessionId(), event.dto());
+		try {
+			redisPublisher.chatMessagePublish(event.sessionId(), event.dto());
+		} catch (Exception e) {
+			log.error("채팅 메시지 Redis 발행 실패 - sessionId: {}, memberId: {}", event.sessionId(), event.dto().getMemberId(), e);
+		}
 	}
 }

--- a/src/main/java/com/example/gak/global/redis/eventHandler/ChatMessageEventHandler.java
+++ b/src/main/java/com/example/gak/global/redis/eventHandler/ChatMessageEventHandler.java
@@ -1,0 +1,22 @@
+package com.example.gak.global.redis.eventHandler;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.example.gak.global.redis.RedisPublisher;
+import com.example.gak.global.redis.event.ChatMessageEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ChatMessageEventHandler {
+
+	private final RedisPublisher redisPublisher;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(ChatMessageEvent event) {
+		redisPublisher.chatMessagePublish(event.sessionId(), event.dto());
+	}
+}


### PR DESCRIPTION
## 작업 내용

> - ChatCommandService: DB 저장 후 ChatMessageEvent 발행으로 변경
> - ChatMessageEvent: 이벤트 record 클래스 추가
> - ChatMessageEventHandler: 트랜잭션 커밋 후 Redis 발행 처리

## 참고 사항

> 

## 연관 이슈

>


<br>