### PR TITLE
feat: SSE 연결 상태 추척으로 세션 연결/해제 관리

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -19,6 +19,7 @@ services:
 
   gak-redis:
     image: redis:alpine
+    command: redis-server --notify-keyspace-events Ex
     volumes:
       - ./redis-data:/data
     healthcheck:

--- a/src/main/java/com/example/gak/domain/session/controller/SessionSseController.java
+++ b/src/main/java/com/example/gak/domain/session/controller/SessionSseController.java
@@ -1,6 +1,7 @@
 package com.example.gak.domain.session.controller;
 
 import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import com.example.gak.domain.session.dto.SessionResponseDTO;
 import com.example.gak.domain.session.dto.enums.EventType;
 import com.example.gak.domain.session.service.SessionQueryService;
+import com.example.gak.global.security.oauth2.CustomOAuth2User;
 import com.example.gak.global.sse.SseService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -63,9 +65,15 @@ public class SessionSseController {
 
 	@Operation(summary = "[SSE] 세션 시작, 종료 알림 SSE")
 	@GetMapping(value = "/{sessionId}/status/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-	public SseEmitter subscribeSessionStartEvents(@PathVariable Long sessionId) {
-
-		SseEmitter emitter = sseService.subscribeSessionStatus(sessionId);
+	public SseEmitter subscribeSessionStartEvents(
+		Authentication authentication,
+		@PathVariable Long sessionId
+	) {
+		Long memberId = null;
+		if (authentication != null && authentication.getPrincipal() instanceof CustomOAuth2User user) {
+			memberId = user.getMemberId();
+		}
+		SseEmitter emitter = sseService.subscribeSessionStatus(sessionId, memberId);
 
 		try {
 			sseService.sendToSessionStatusEmitter(

--- a/src/main/java/com/example/gak/domain/session/entity/SessionRoomMember.java
+++ b/src/main/java/com/example/gak/domain/session/entity/SessionRoomMember.java
@@ -52,8 +52,6 @@ public class SessionRoomMember extends BaseEntity {
 	@Column(nullable = false)
 	private SessionParticipantStatus status = SessionParticipantStatus.FOCUSED;
 
-	private boolean isAbnormalExit;
-
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "session_room_id", nullable = false)
 	private SessionRoom sessionRoom;
@@ -86,17 +84,12 @@ public class SessionRoomMember extends BaseEntity {
 		Member member
 	) {
 		this.role = role;
-		this.isAbnormalExit = false;
 		this.sessionRoom = sessionRoom;
 		this.member = member;
 	}
 
 	public void changeParticipantRole(SessionParticipantRole role) {
 		this.role = role;
-	}
-
-	public void markAsAbnormalExit() {
-		this.isAbnormalExit = true;
 	}
 
 	public void toggleStatus() {

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -165,6 +165,28 @@ public class SessionCommandService {
 		return SessionParticipantRole.PARTICIPANT;
 	}
 
+	public void leaveSessionOnDisconnect(Long sessionId, Long memberId) {
+		SessionRoom sessionRoom = sessionRoomRepository.findById(sessionId).orElse(null);
+		if (sessionRoom == null || sessionRoom.getStatus() == COMPLETED) {
+			return;
+		}
+
+		int deleted = sessionRoomMemberRepository.deleteByMemberIdAndSessionRoomId(memberId, sessionId);
+		if (deleted == 0) {
+			return;
+		}
+
+		taskRepository.findWithSessionRoomBySessionRoomIdAndMemberId(sessionId, memberId)
+			.ifPresent(task -> {
+				taskRepository.delete(task);
+				taskRepository.flush();
+			});
+
+		sessionRoomRepository.decreaseCount(sessionId);
+		hostPermissionTransfer(sessionId);
+		publishSessionRoomUpdateEvent(sessionRoom.getStatus(), sessionId);
+	}
+
 	public void leaveSession(Long sessionId, Long memberId) {
 		int deleted = sessionRoomMemberRepository
 			.deleteByMemberIdAndSessionRoomId(memberId, sessionId);

--- a/src/main/java/com/example/gak/global/redis/RedisConfig.java
+++ b/src/main/java/com/example/gak/global/redis/RedisConfig.java
@@ -4,10 +4,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.example.gak.global.sse.PresenceService;
 
 @Configuration
 public class RedisConfig {
@@ -26,7 +29,8 @@ public class RedisConfig {
 	@Bean
 	public RedisMessageListenerContainer redisMessageListenerContainer(
 		RedisConnectionFactory connectionFactory,
-		RedisSubscriber redisSubscriber
+		RedisSubscriber redisSubscriber,
+		PresenceService presenceService
 	) {
 		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
 
@@ -37,8 +41,9 @@ public class RedisConfig {
 		container.addMessageListener(redisSubscriber, new PatternTopic("session/*"));
 		container.addMessageListener(redisSubscriber, new PatternTopic("reaction/*"));
 		container.addMessageListener(redisSubscriber, new PatternTopic("member/*/reaction/*"));
-
 		container.addMessageListener(redisSubscriber, new PatternTopic("chat/*"));
+
+		container.addMessageListener(presenceService, new ChannelTopic("__keyevent@0__:expired"));
 
 		return container;
 	}

--- a/src/main/java/com/example/gak/global/security/AccessTokenFreeUrls.java
+++ b/src/main/java/com/example/gak/global/security/AccessTokenFreeUrls.java
@@ -12,11 +12,6 @@ public final class AccessTokenFreeUrls {
 		"/swagger-ui/**",
 		"/v3/api-docs/**",
 		"/api/v1/sessions",
-		"/api/v1/sessions/{sessionId:\\d+}/waiting-room/events",
-		"/api/v1/sessions/{sessionId:\\d+}/in-progress/events",
-		"/api/v1/sessions/{sessionId:\\d+}/status/events",
-		"/api/v1/sessions/{sessionId:\\d+}/reaction/events",
-		"/api/v1/sessions/{sessionId:\\d+}/members/{memberId:\\d+}/reaction/events",
 		"/ws/**"
 	};
 }

--- a/src/main/java/com/example/gak/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/example/gak/global/security/JwtAuthFilter.java
@@ -50,8 +50,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 				return;
 			}
 
-			String accessToken = authorizationHeader.split(" ")[1];
-			memberId = jwtProvider.extractMemberId(accessToken);
+			memberId = jwtProvider.extractMemberId(authorizationHeader.substring(BEARER_PREFIX.length()));
 		} catch (ExpiredJwtException e) {
 			sendErrorResponse(response, GeneralErrorCode.ACCESS_TOKEN_EXPIRED);
 			return;

--- a/src/main/java/com/example/gak/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/gak/global/security/SecurityConfig.java
@@ -11,6 +11,8 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import jakarta.servlet.DispatcherType;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -53,6 +55,7 @@ public class SecurityConfig {
 				.successHandler(successHandler)
 				.failureHandler(failureHandler))
 			.authorizeHttpRequests(auth -> auth
+				.dispatcherTypeMatchers(DispatcherType.ASYNC, DispatcherType.ERROR).permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/v1/sessions/*").permitAll()
 				.requestMatchers(AccessTokenFreeUrls.PATHS).permitAll()
 				.anyRequest().authenticated())

--- a/src/main/java/com/example/gak/global/sse/PresenceService.java
+++ b/src/main/java/com/example/gak/global/sse/PresenceService.java
@@ -1,0 +1,54 @@
+package com.example.gak.global.sse;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Service;
+
+import com.example.gak.domain.session.service.SessionCommandService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PresenceService {
+
+	private static final long GRACE_PERIOD_SECONDS = 30;
+
+	private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
+	private final ConcurrentHashMap<String, ScheduledFuture<?>> pendingLeaves = new ConcurrentHashMap<>();
+
+	private final SessionCommandService sessionCommandService;
+
+	public void onConnect(Long sessionId, Long memberId) {
+		String key = key(sessionId, memberId);
+		ScheduledFuture<?> pending = pendingLeaves.remove(key);
+		if (pending != null) {
+			pending.cancel(false);
+			log.info("presence reconnected — cancelled pending leave: session={}, member={}", sessionId, memberId);
+		}
+	}
+
+	public void onDisconnect(Long sessionId, Long memberId) {
+		String key = key(sessionId, memberId);
+		ScheduledFuture<?> future = scheduler.schedule(() -> {
+			pendingLeaves.remove(key);
+			try {
+				sessionCommandService.leaveSessionOnDisconnect(sessionId, memberId);
+			} catch (Exception e) {
+				log.warn("presence leave failed: session={}, member={}", sessionId, memberId, e);
+			}
+		}, GRACE_PERIOD_SECONDS, TimeUnit.SECONDS);
+		pendingLeaves.put(key, future);
+		log.info("presence disconnected — grace period started: session={}, member={}", sessionId, memberId);
+	}
+
+	private String key(Long sessionId, Long memberId) {
+		return sessionId + ":" + memberId;
+	}
+}

--- a/src/main/java/com/example/gak/global/sse/PresenceService.java
+++ b/src/main/java/com/example/gak/global/sse/PresenceService.java
@@ -1,13 +1,13 @@
 package com.example.gak.global.sse;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import com.example.gak.domain.session.repository.SessionRoomMemberRepository;
 import com.example.gak.domain.session.service.SessionCommandService;
 
 import lombok.RequiredArgsConstructor;
@@ -16,39 +16,53 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class PresenceService {
+public class PresenceService implements MessageListener {
 
-	private static final long GRACE_PERIOD_SECONDS = 30;
+	private static final long GRACE_PERIOD_SECONDS = 10;
+	private static final String KEY_PREFIX = "grace:";
 
-	private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
-	private final ConcurrentHashMap<String, ScheduledFuture<?>> pendingLeaves = new ConcurrentHashMap<>();
-
+	private final StringRedisTemplate redisTemplate;
 	private final SessionCommandService sessionCommandService;
+	private final SessionRoomMemberRepository sessionRoomMemberRepository;
 
 	public void onConnect(Long sessionId, Long memberId) {
-		String key = key(sessionId, memberId);
-		ScheduledFuture<?> pending = pendingLeaves.remove(key);
-		if (pending != null) {
-			pending.cancel(false);
-			log.info("presence reconnected — cancelled pending leave: session={}, member={}", sessionId, memberId);
+		String key = KEY_PREFIX + sessionId + ":" + memberId;
+		Boolean deleted = redisTemplate.delete(key);
+		if (Boolean.TRUE.equals(deleted)) {
+			log.info("presence 재연결 — 퇴장 타이머 취소: session={}, member={}", sessionId, memberId);
 		}
 	}
 
 	public void onDisconnect(Long sessionId, Long memberId) {
-		String key = key(sessionId, memberId);
-		ScheduledFuture<?> future = scheduler.schedule(() -> {
-			pendingLeaves.remove(key);
-			try {
-				sessionCommandService.leaveSessionOnDisconnect(sessionId, memberId);
-			} catch (Exception e) {
-				log.warn("presence leave failed: session={}, member={}", sessionId, memberId, e);
-			}
-		}, GRACE_PERIOD_SECONDS, TimeUnit.SECONDS);
-		pendingLeaves.put(key, future);
-		log.info("presence disconnected — grace period started: session={}, member={}", sessionId, memberId);
+		if (!sessionRoomMemberRepository.existsBySessionRoomIdAndMemberId(sessionId, memberId)) {
+			return;
+		}
+		String key = KEY_PREFIX + sessionId + ":" + memberId;
+		redisTemplate.opsForValue().set(key, "1", Duration.ofSeconds(GRACE_PERIOD_SECONDS));
+		log.info("presence 연결 끊김 — 유예 타이머 시작 ({}초): session={}, member={}", GRACE_PERIOD_SECONDS, sessionId, memberId);
 	}
 
-	private String key(Long sessionId, Long memberId) {
-		return sessionId + ":" + memberId;
+	@Override
+	public void onMessage(Message message, byte[] pattern) {
+		String expiredKey = new String(message.getBody());
+		if (!expiredKey.startsWith(KEY_PREFIX)) {
+			return;
+		}
+
+		String[] parts = expiredKey.substring(KEY_PREFIX.length()).split(":");
+		if (parts.length != 2) {
+			return;
+		}
+
+		try {
+			Long sessionId = Long.parseLong(parts[0]);
+			Long memberId = Long.parseLong(parts[1]);
+			log.info("presence 유예 시간 만료 — 자동 퇴장 처리: session={}, member={}", sessionId, memberId);
+			sessionCommandService.leaveSessionOnDisconnect(sessionId, memberId);
+		} catch (NumberFormatException e) {
+			log.warn("grace 키 형식 오류: {}", expiredKey);
+		} catch (Exception e) {
+			log.warn("presence 자동 퇴장 처리 실패: key={}", expiredKey, e);
+		}
 	}
 }

--- a/src/main/java/com/example/gak/global/sse/SseService.java
+++ b/src/main/java/com/example/gak/global/sse/SseService.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -14,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class SseService {
+
+	private final PresenceService presenceService;
 
 	private final Map<Long, List<SseEmitter>> waitingEmitters = new ConcurrentHashMap<>();
 	private final Map<Long, List<SseEmitter>> inProgressEmitters = new ConcurrentHashMap<>();
@@ -109,16 +112,28 @@ public class SseService {
 		}
 	}
 
-	public SseEmitter subscribeSessionStatus(Long sessionId) {
+	public SseEmitter subscribeSessionStatus(Long sessionId, Long memberId) {
 		SseEmitter emitter = new SseEmitter(60 * 60 * 1000L);
 
 		sessionStatusEmitters
 			.computeIfAbsent(sessionId, k -> new CopyOnWriteArrayList<>())
 			.add(emitter);
 
-		emitter.onCompletion(() -> removeSessionStatusEmitter(sessionId, emitter));
-		emitter.onTimeout(() -> removeSessionStatusEmitter(sessionId, emitter));
-		emitter.onError(e -> removeSessionStatusEmitter(sessionId, emitter));
+		if (memberId != null) {
+			presenceService.onConnect(sessionId, memberId);
+
+			Runnable onDisconnect = () -> {
+				removeSessionStatusEmitter(sessionId, emitter);
+				presenceService.onDisconnect(sessionId, memberId);
+			};
+			emitter.onCompletion(onDisconnect);
+			emitter.onTimeout(onDisconnect);
+			emitter.onError(e -> onDisconnect.run());
+		} else {
+			emitter.onCompletion(() -> removeSessionStatusEmitter(sessionId, emitter));
+			emitter.onTimeout(() -> removeSessionStatusEmitter(sessionId, emitter));
+			emitter.onError(e -> removeSessionStatusEmitter(sessionId, emitter));
+		}
 
 		return emitter;
 	}
@@ -234,6 +249,20 @@ public class SseService {
 		List<SseEmitter> emitters = memberReactionEmitters.get(key);
 		if (emitters != null) {
 			emitters.remove(emitter);
+		}
+	}
+
+	@Scheduled(fixedDelay = 5000)
+	public void sendHeartbeat() {
+		for (Map.Entry<Long, List<SseEmitter>> entry : sessionStatusEmitters.entrySet()) {
+			List<SseEmitter> emitters = entry.getValue();
+			for (SseEmitter emitter : emitters) {
+				try {
+					emitter.send(SseEmitter.event().comment("heartbeat"));
+				} catch (IOException e) {
+					emitter.completeWithError(e);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## 작업 내용

- SSE 엔드포인트 JWT 인증 적용
  - 기존 `AccessTokenFreeUrls.PATHS`에 열려 있던 SSE 엔드포인트 5개를 인증 필요 경로로 전환했습니다.
    - `/waiting-room/events`
    - `/in-progress/events`
    - `/status/events`
    - `/reaction/events`
    - `/members/{memberId}/reaction/events`
  - SSE 응답이 비동기(`ASYNC`) 디스패처 타입으로 처리되는 점을 고려해, `SecurityConfig`에 `DispatcherType.ASYNC`, `DispatcherType.ERROR`를 `permitAll()`로 등록했습니다.

- SSE 연결 상태 기반 자동 퇴장 처리
  - SSE 연결이 끊겼을 때 즉시 퇴장 처리하지 않고, 10초의 유예 시간을 두어 재연결을 허용하도록 구현했습니다.
  - 연결 끊김 시 Redis에 `grace:{sessionId}:{memberId}` 키를 TTL 10초로 저장합니다.
  - 재연결 시 grace key가 존재하면 삭제하여 자동 퇴장 타이머를 취소합니다.
  - TTL 만료 시 Redis keyspace notification을 수신하여 `SessionCommandService.leaveSessionOnDisconnect()`를 호출하고 자동 퇴장을 처리합니다.

- Redis keyspace notification 설정 추가
  - 로컬 Redis 환경에서 key expiration 이벤트를 수신할 수 있도록 `compose.yaml`에 `--notify-keyspace-events KEA` 옵션을 추가했습니다.

- `SessionRoomMember` 미사용 필드 및 메서드 제거
  - 이전 리팩토링 이후 실제로 사용되지 않는 필드와 메서드를 정리했습니다.

## 참고 사항

- 운영 환경 Redis에도 `notify-keyspace-events KEA` 설정이 적용되어 있어야 자동 퇴장 기능이 정상 동작합니다.
- `PresenceService`는 `RedisConfig`의 `__keyevent@0__:expired` 채널 구독자로 등록되어 있으며, 기존 `RedisSubscriber`와 독립적으로 동작합니다.
- SSE 인증 적용 이후 클라이언트는 SSE 구독 요청 시에도 `Authorization: Bearer <token>` 헤더를 포함해야 합니다.
- `/status/events` 구독 진입 시 `onConnect()`가 호출되며, `SseService`의 emitter `completion`, `timeout`, `error` 콜백에서 `onDisconnect()`가 호출됩니다.

## 연관 이슈

close #127