### PR TITLE
refactor: endSession() N+1 쿼리 개선

### DIFF
--- a/src/main/java/com/example/gak/domain/record/repository/RecordRepository.java
+++ b/src/main/java/com/example/gak/domain/record/repository/RecordRepository.java
@@ -1,6 +1,10 @@
 package com.example.gak.domain.record.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.gak.domain.member.entity.Member;
 import com.example.gak.domain.record.entity.Record;
@@ -12,4 +16,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 	Record findByMemberId(Long memberId);
 
 	Record findByMember(Member member);
+
+	@Query("SELECT r FROM Record r WHERE r.member.id IN :memberIds")
+	List<Record> findByMemberIdIn(@Param("memberIds") List<Long> memberIds);
 }

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -11,6 +11,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -354,11 +356,28 @@ public class SessionCommandService {
 		}
 
 		List<SessionRoomMember> sessionRoomMembers = sessionRoom.getSessionRoomMembers();
+		if (sessionRoomMembers.isEmpty()) {
+			applicationEventPublisher.publishEvent(new SessionStatusUpdateEvent(sessionId));
+			return;
+		}
+
+		Map<Long, Task> taskByMemberId = taskRepository.findAllWithSubTasksBySessionRoomId(sessionId)
+			.stream()
+			.collect(Collectors.toMap(t -> t.getMember().getId(), Function.identity()));
+
+		List<Long> memberIds = sessionRoomMembers.stream()
+			.map(m -> m.getMember().getId())
+			.toList();
+
+		Map<Long, Record> recordByMemberId = recordRepository.findByMemberIdIn(memberIds)
+			.stream()
+			.collect(Collectors.toMap(r -> r.getMember().getId(), Function.identity()));
 
 		for (SessionRoomMember member : sessionRoomMembers) {
-			Optional<Task> taskOpt = taskRepository.findWithSessionRoomBySessionRoomIdAndMemberId(sessionId,
-				member.getMember().getId());
-			if (taskOpt.isEmpty()) {
+			Long memberId = member.getMember().getId();
+			Task task = taskByMemberId.get(memberId);
+
+			if (task == null) {
 				// grace 기간 만료로 이미 퇴장 처리된 멤버 — 통계 대상에서 제외
 				continue;
 			}
@@ -380,9 +399,9 @@ public class SessionCommandService {
 
 			member.updateFocusRate();
 
-			List<SubTask> subTasks = subTaskRepository.findByTaskId(taskOpt.get().getId());
+			List<SubTask> subTasks = task.getSubTasks();
 			member.updateAchievementRate(subTasks);
-			sessionSaveToRecord(member.getMember(), member, subTasks);
+			sessionSaveToRecord(recordByMemberId.get(memberId), member, subTasks);
 		}
 
 		applicationEventPublisher.publishEvent(
@@ -415,14 +434,13 @@ public class SessionCommandService {
 		List<SubTask> subTasks = subTaskRepository.findByTaskId(task.getId());
 
 		sessionRoomMember.updateAchievementRate(subTasks);
-		sessionSaveToRecord(sessionRoomMember.getMember(), sessionRoomMember, subTasks);
+		Record record = recordRepository.findByMemberId(memberId);
+		sessionSaveToRecord(record, sessionRoomMember, subTasks);
 	}
 
 	private void sessionSaveToRecord(
-		Member member, SessionRoomMember sessionRoomMember, List<SubTask> subTasks
+		Record record, SessionRoomMember sessionRoomMember, List<SubTask> subTasks
 	) {
-		Record record = recordRepository.findByMember(member);
-
 		if (record == null)
 			return;
 

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -378,30 +378,10 @@ public class SessionCommandService {
 			Task task = taskByMemberId.get(memberId);
 
 			if (task == null) {
-				// grace 기간 만료로 이미 퇴장 처리된 멤버 — 통계 대상에서 제외
 				continue;
 			}
 
-			if (member.getStatus() == SessionParticipantStatus.FOCUSED) {
-				int seconds = (int)Duration.between(
-					member.getLastFocusTime(),
-					sessionRoom.getEndTime()
-				).getSeconds();
-				member.updateFocusSeconds(seconds);
-			}
-
-			member.setOverallSeconds(
-				(int)Duration.between(
-					member.getCreatedAt(),
-					sessionRoom.getEndTime()
-				).getSeconds()
-			);
-
-			member.updateFocusRate();
-
-			List<SubTask> subTasks = task.getSubTasks();
-			member.updateAchievementRate(subTasks);
-			sessionSaveToRecord(recordByMemberId.get(memberId), member, subTasks);
+			processMemberStats(member, task, sessionRoom, recordByMemberId.get(memberId));
 		}
 
 		applicationEventPublisher.publishEvent(
@@ -625,6 +605,28 @@ public class SessionCommandService {
 		}
 
 		sessionRoom.updateSession(request);
+	}
+
+	private void processMemberStats(SessionRoomMember member, Task task, SessionRoom sessionRoom, Record record) {
+		if (member.getStatus() == SessionParticipantStatus.FOCUSED) {
+			int seconds = (int)Duration.between(
+				member.getLastFocusTime(),
+				sessionRoom.getEndTime()
+			).getSeconds();
+			member.updateFocusSeconds(seconds);
+		}
+
+		member.setOverallSeconds(
+			(int)Duration.between(
+				member.getCreatedAt(),
+				sessionRoom.getEndTime()
+			).getSeconds()
+		);
+		member.updateFocusRate();
+
+		List<SubTask> subTasks = task.getSubTasks();
+		member.updateAchievementRate(subTasks);
+		sessionSaveToRecord(record, member, subTasks);
 	}
 
 	private SessionResponseDTO.taskResponseDTO saveGoalTask(SessionRoom sessionRoom, Member member,

--- a/src/main/java/com/example/gak/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/example/gak/domain/task/repository/TaskRepository.java
@@ -24,4 +24,7 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 	);
 
 	List<Task> findBySessionRoomId(Long sessionRoomId);
+
+	@Query("SELECT DISTINCT t FROM Task t LEFT JOIN FETCH t.subTasks JOIN FETCH t.member WHERE t.sessionRoom.id = :sessionId")
+	List<Task> findAllWithSubTasksBySessionRoomId(@Param("sessionId") Long sessionId);
 }


### PR DESCRIPTION
## 작업 내용

  - `TaskRepository`에 `findAllWithSubTasksBySessionRoomId()` 추가 — Task + SubTask + Member JOIN FETCH 일괄 조회
  - `RecordRepository`에 `findByMemberIdIn()` 추가 — IN절 일괄 조회
  - `endSession()` 루프 내 개별 쿼리를 Map 조회로 전환
  - `sessionSaveToRecord()` 시그니처 `Member` → `Record`로 변경
  
  ## 참고 사항

  기능 변경 없이 쿼리 방식만 변경되었습니다.
  `sessionSaveToRecord()` 시그니처 변경으로 인해 `postSessionResult()` 호출부도 함께 수정되었습니다.

  ## 연관 이슈

  close #137
