### PR TITLE
fix: STOMP 엔드포인트 SockJS 제거하고 순수 웹소켓으로 전환

### DIFF
--- a/src/main/java/com/example/gak/global/webSocket/WebSocketConfig.java
+++ b/src/main/java/com/example/gak/global/webSocket/WebSocketConfig.java
@@ -25,8 +25,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
 		registry.addEndpoint("/ws")
-			.setAllowedOriginPatterns("*")
-			.withSockJS();
+			.setAllowedOriginPatterns("*");
 	}
 
 	@Override


### PR DESCRIPTION
## 작업 내용

- STOMP 엔드포인트(`/ws`)에서 SockJS 등록(`.withSockJS()`)을 제거하고 순수 WebSocket 엔드포인트로 전환했습니다.
- 최신 브라우저는 모두 WebSocket을 기본 지원하므로 SockJS의 폴백(xhr-streaming/polling 등) 우회 접속 기능이 더 이상 필요하지 않아 제거했습니다.

## 참고 사항


## 연관 이슈

> close #142 


<br>