### PR TITLE
fix: 세션 시작/종료 스케줄러 다중 인스턴스 중복 처리 방지

### DIFF
--- a/src/main/java/com/example/gak/domain/session/repository/SessionRoomRepository.java
+++ b/src/main/java/com/example/gak/domain/session/repository/SessionRoomRepository.java
@@ -66,6 +66,10 @@ public interface SessionRoomRepository extends JpaRepository<SessionRoom, Long>,
 		""")
 	int decreaseCountBy(@Param("sessionRoomId") Long sessionRoomId, @Param("count") int count);
 
+	@Modifying(clearAutomatically = true)
+	@Query("UPDATE SessionRoom s SET s.status = :to WHERE s.id = :id AND s.status = :from")
+	int transitionStatus(@Param("id") Long id, @Param("from") SessionRoomStatus from, @Param("to") SessionRoomStatus to);
+
 	List<SessionRoom> findByStatusAndStartTimeBefore(SessionRoomStatus status, LocalDateTime dateTime);
 
 	List<SessionRoom> findByStatusAndEndTimeBefore(SessionRoomStatus status, LocalDateTime time);

--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -330,12 +330,13 @@ public class SessionCommandService {
 	}
 
 	public void startSession(Long sessionId) {
+		int updated = sessionRoomRepository.transitionStatus(sessionId, WAITING, SessionRoomStatus.IN_PROGRESS);
+		if (updated == 0) {
+			return;
+		}
+
 		SessionRoom sessionRoom = sessionRoomRepository.findById(sessionId)
 			.orElseThrow(() -> new GeneralException(NOT_FOUND_SESSION));
-
-		if (sessionRoom.getStatus() == WAITING) {
-			sessionRoom.changeStatus(SessionRoomStatus.IN_PROGRESS);
-		}
 
 		List<SessionRoomMember> sessionRoomMembers = sessionRoom.getSessionRoomMembers();
 		for (SessionRoomMember member : sessionRoomMembers) {
@@ -348,12 +349,14 @@ public class SessionCommandService {
 	}
 
 	public void endSession(Long sessionId) {
+		int updated = sessionRoomRepository.transitionStatus(
+			sessionId, SessionRoomStatus.IN_PROGRESS, SessionRoomStatus.COMPLETED);
+		if (updated == 0) {
+			return;
+		}
+
 		SessionRoom sessionRoom = sessionRoomRepository.findById(sessionId)
 			.orElseThrow(() -> new GeneralException(NOT_FOUND_SESSION));
-
-		if (sessionRoom.getStatus() == SessionRoomStatus.IN_PROGRESS) {
-			sessionRoom.changeStatus(SessionRoomStatus.COMPLETED);
-		}
 
 		List<SessionRoomMember> sessionRoomMembers = sessionRoom.getSessionRoomMembers();
 		if (sessionRoomMembers.isEmpty()) {


### PR DESCRIPTION
## 작업 내용

  여러 서버 인스턴스 환경에서 `SessionScheduler`가 동시에 같은 세션의 `startSession()`/`endSession()`을 호출할 때 발생하는 중복 처리 문제를 수정했습니다.                                                                       
                                                                                                                                                                                                                                
  - 기존에는 `findById()`로 상태를 읽고 애플리케이션 메모리에서 `if (status == X)`를 체크한 뒤 `changeStatus()`를 호출하는 read-then-write 구조라, 두 인스턴스가 동시에 같은 세션을 처리하면 둘 다 조건을 통과해버리는 레이스 컨디션이 있었습니다.                                                                                                                                                                                                          
  - `endSession()`의 경우 `Record`에 대한 통계 누적(`increaseFocusedTime`, `increaseTotalTodoCount` 등)이 중복 실행되어 실제 값이 2배로 기록될 수 있는 문제였습니다.                                                            
  - `SessionRoomRepository`에 조건부 UPDATE(`transitionStatus`)를 추가해, 상태 전이 자체를 원자적 연산으로 바꿨습니다. `WHERE status = :from` 조건을 만족하지 못하면(= 다른 인스턴스가 이미 처리함) `affected row = 0`을 받고   
  해당 세션 처리를 스킵합니다.                                                                                                                                                                                                  
  - `currentCount` 증감(`increaseCountIfJoinable`, `decreaseCount` 등)에 이미 쓰이던 것과 동일한 패턴입니다.

## 참고 사항

- `startSession`/`endSession` 둘 다 메서드 진입 즉시 `transitionStatus()`를 호출하고, `updated == 0`이면 바로 return하도록 바뀌었습니다. 이후 로직(멤버 순회, 통계 누적, 이벤트 발행)은 상태 전이에 성공한 인스턴스에서만 실행됩니다.
- 별도 분산락(Redis/Redisson) 없이 DB 트랜잭션의 원자성만으로 해결했습니다. 락 획득 실패, TTL 관리 같은 실패 모드가 없고, 세션 단위로 자연스럽게 처리가 분산됩니다.
- 부작용으로, `endSession()` 처리 중(상태전이 UPDATE ~ 커밋까지) 같은 세션에 대한 join/leave 요청은 row 락 경합으로 잠깐 블로킹될 수 있습니다. 실패가 아니라 지연이며, 현재 세션 규모에서는 감수 가능한 수준이라 판단했습니다. 이후 세션 인원/트래픽이 늘어나면 **상태전이(짧은 트랜잭션)와 통계처리(별도 트랜잭션)를 분리**해 락 보유 시간을 줄이거나, `SELECT ... FOR UPDATE NOWAIT` 기반으로 블로킹 대신 즉시 스킵하는 방식으로 전환할 예정입니다.

## 연관 이슈

> close #144


<br>