### PR TITLE
fix: 세션 참여 시간 계산 시 대기방 입장 시각 대신 세션 진행 시작 시각을 기준으로 하도록 수정

### DIFF
--- a/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
+++ b/src/main/java/com/example/gak/domain/session/service/SessionCommandService.java
@@ -680,11 +680,12 @@ public class SessionCommandService {
 			member.updateFocusSeconds(seconds);
 		}
 
+		LocalDateTime participationStart = member.getCreatedAt().isBefore(sessionRoom.getStartTime())
+			? sessionRoom.getStartTime()
+			: member.getCreatedAt();
+
 		member.setOverallSeconds(
-			(int)Duration.between(
-				member.getCreatedAt(),
-				sessionRoom.getEndTime()
-			).getSeconds()
+			(int)Duration.between(participationStart, sessionRoom.getEndTime()).getSeconds()
 		);
 		member.updateFocusRate();
 


### PR DESCRIPTION
## 작업 내용

세션 참여 시간(`overallSeconds`) 계산 기준을 "대기방 입장 시각"에서 "세션 진행 시작 시각"으로 수정했습니다.

- 기존: `SessionCommandService.processMemberStats()`에서 `member.getCreatedAt()`(=대기방 입장 시각, `WAITING` 단계에서 세션에 참여한 시각)부터 `sessionRoom.getEndTime()`까지를 참여 시간으로 계산 → 30분 세션인데 대기 12분을 포함해 42분으로 집계되는 문제
- 수정: `sessionRoom.getStartTime()`(진행 시작 시각)과 `member.getCreatedAt()` 중 더 늦은 시각을 기준점으로 사용
  - 대기방에 미리 들어온 경우 → 진행 시작 시각부터 계산
  - 세션 도중 참여(late join)한 경우 → 본인이 실제로 참여한 시각부터 계산
- 이 값이 집중도(`focusRate`) 계산의 분모로 쓰이고 있어, 대기방에 일찍 들어올수록(성실할수록) 오히려 집중률이 낮게 나오는 역설이 있었습니다. 분자(`totalFocusSeconds`)는 `lastFocusTime`이 세션 시작 시점에 이미 정확히 리셋되고 있어 문제 없었고, 분모만 기준이 어긋나 있던 것이 원인입니다.
- 마이페이지 세션 목록에서 세션 소요 시간 대신 이 값이 그대로 노출되던 문제도 동일한 필드를 참조하고 있어 함께 해결됩니다.

## 참고 사항

- 수정 범위는 `SessionCommandService.processMemberStats()` 한 곳입니다.
- 이미 완료되어 `Record`에 누적된 과거 세션(8/3, 8/4 등)의 오염된 데이터는 이번 PR에서 소급 보정하지 않았습니다. `Record`는 세션별 원장 없이 누적 합계만 갖고 있어, 보정하려면 별도 백필 작업이 필요합니다.

## 연관 이슈

close #147