### PR TITLE
fix: 시간대 필터의 오전 구간을 0시부터로 확장해 새벽 세션도 조회 가능하도록 수정

### DIFF
--- a/src/main/java/com/example/gak/domain/session/repository/SessionSpecification.java
+++ b/src/main/java/com/example/gak/domain/session/repository/SessionSpecification.java
@@ -58,7 +58,7 @@ public class SessionSpecification {
 				for (TimeSlot slot : timeSlots) {
 					switch (slot) {
 						case MORNING -> slotPredicates.add(
-							cb.between(cb.function("HOUR", Integer.class, root.get("startTime")), 6, 11)
+							cb.between(cb.function("HOUR", Integer.class, root.get("startTime")), 0, 11)
 						);
 						case AFTERNOON -> slotPredicates.add(
 							cb.between(cb.function("HOUR", Integer.class, root.get("startTime")), 12, 17)


### PR DESCRIPTION
## 작업 내용

시간대(`TimeSlot`) 필터가 오전(6 -11시)/오후(12 - 17시)/저녁(18 - 23시) 3개 구간만 커버하고 있어, 0~5시(새벽)에 시작하는 세션은 어떤 필터로도 조회되지 않는 문제를 수정했습니다.

- 세션 생성 시 시작 시각에 대한 제약이 없어 새벽 시간대 세션 생성 자체는 가능했지만, 조회 필터에는 해당 구간이 존재하지 않아 "만들 수는 있는데 찾을 수는 없는" 데이터가 생기고 있었습니다.
- `SessionSpecification`의 `MORNING` 조건을 `HOUR BETWEEN 6 AND 11` → `HOUR BETWEEN 0 AND 11`로 확장해, 0~11시 세션이 모두 오전 필터에 포함되도록 수정했습니다.

## 참고 사항

- 새 enum 값(예: `DAWN`)을 추가하는 대신 기존 `MORNING` 구간을 확장하는 방식으로 처리했습니다. 프론트엔드 수정 없이 바로 적용 가능합니다.
- `HOUR()` 함수 기준이라 분/초와 무관하게 `11:59:59`까지는 오전, `12:00:00`부터 오후로 분류됩니다.
- `AFTERNOON`, `EVENING` 구간은 변경하지 않았습니다.

## 연관 이슈

close #149