### PR TITLE
fix: 목표 수정 API에 참여 시와 동일한 50자 길이 검증 추가

### DIFF
--- a/src/main/java/com/example/gak/domain/task/controller/TaskController.java
+++ b/src/main/java/com/example/gak/domain/task/controller/TaskController.java
@@ -19,6 +19,7 @@ import com.example.gak.global.security.oauth2.CustomOAuth2User;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "목표 API")
@@ -34,7 +35,7 @@ public class TaskController {
 	public ApiResponse<Void> updateTask(
 		@AuthenticationPrincipal CustomOAuth2User oAuth2User,
 		@PathVariable Long taskId,
-		@RequestBody TaskRequestDTO.UpdateTaskDTO request
+		@RequestBody @Valid TaskRequestDTO.UpdateTaskDTO request
 	) {
 		taskCommandService.updateTask(taskId, oAuth2User.getMemberId(), request);
 		return ApiResponse.onSuccess(null);

--- a/src/main/java/com/example/gak/domain/task/dto/TaskRequestDTO.java
+++ b/src/main/java/com/example/gak/domain/task/dto/TaskRequestDTO.java
@@ -1,6 +1,8 @@
 package com.example.gak.domain.task.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +12,8 @@ public class TaskRequestDTO {
 	@Getter
 	@Builder
 	public static class UpdateTaskDTO {
+		@NotNull
+		@Size(max = 50)
 		private String goalContent;
 	}
 }


### PR DESCRIPTION
## 작업 내용

세션 목표(goal) 수정 API에 참여(join) API와 동일한 50자 길이 검증을 추가했습니다.

- 세션 참여 시(`SessionJoinRequestDTO.goal`)는 `@NotNull @Size(max = 50)`으로 50자 제한이 걸려있지만, 대기실 "수정하기"로 목표를 바꾸는 API(`TaskRequestDTO.UpdateTaskDTO.goalContent`)에는 아무 검증도 없었습니다.
- `TaskController.updateTask()`의 `@RequestBody`에도 `@Valid`가 빠져 있어, DTO에 제약을 걸어도 애초에 실행되지 않는 상태였습니다.
- 실제로 52자짜리 목표로 수정 API를 호출하면 200으로 저장에 성공하는 것을 확인했습니다(경로별 검증 불일치).

## 참고 사항

## 연관 이슈

close #151